### PR TITLE
Fix React wrapper tag names

### DIFF
--- a/packages/cre8-react/src/components/Accordion/Accordion.tsx
+++ b/packages/cre8-react/src/components/Accordion/Accordion.tsx
@@ -15,6 +15,6 @@ import { Cre8Accordion as Cre8AccordionElement } from '@cre8_dev/cre8-wc/lib/com
 
 export const Cre8Accordion = createComponent({
     react: React,
-    tagName: 'Cre8-accordion',
+    tagName: 'cre8-accordion',
     elementClass: Cre8AccordionElement,
 });

--- a/packages/cre8-react/src/components/AccordionItem/AccordionItem.tsx
+++ b/packages/cre8-react/src/components/AccordionItem/AccordionItem.tsx
@@ -28,6 +28,6 @@ import { Cre8AccordionItem as Cre8AccordionItemElement } from '@cre8_dev/cre8-wc
 
 export const Cre8AccordionItem = createComponent({
     react: React,
-    tagName: 'Cre8-accordion-item',
+    tagName: 'cre8-accordion-item',
     elementClass: Cre8AccordionItemElement,
 });

--- a/packages/cre8-react/src/components/Alert/Alert.tsx
+++ b/packages/cre8-react/src/components/Alert/Alert.tsx
@@ -19,6 +19,6 @@ import { Cre8Alert as Cre8AlertElement } from '@cre8_dev/cre8-wc/lib/components/
 
 export const Cre8Alert = createComponent({
     react: React,
-    tagName: 'Cre8-alert',
+    tagName: 'cre8-alert',
     elementClass: Cre8AlertElement,
 });

--- a/packages/cre8-react/src/components/Badge/Badge.tsx
+++ b/packages/cre8-react/src/components/Badge/Badge.tsx
@@ -10,6 +10,6 @@ import React from 'react';
 
 export const Cre8Badge = createComponent({
     react: React,
-    tagName: 'Cre8-badge',
+    tagName: 'cre8-badge',
     elementClass: Cre8BadgeElement,
 });

--- a/packages/cre8-react/src/components/Band/Band.tsx
+++ b/packages/cre8-react/src/components/Band/Band.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const Cre8Band = createComponent({
     react: React,
-    tagName: 'Cre8-band',
+    tagName: 'cre8-band',
     elementClass: Cre8BandElement,
 });

--- a/packages/cre8-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/cre8-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -20,7 +20,7 @@ import { Cre8Breadcrumbs as Cre8BreadcrumbsElement } from '@cre8_dev/cre8-wc/lib
 
 export const Cre8Breadcrumbs = createComponent({
     react: React,
-    tagName: 'Cre8-breadcrumbs',
+    tagName: 'cre8-breadcrumbs',
     elementClass: Cre8BreadcrumbsElement,
 
 });

--- a/packages/cre8-react/src/components/BreadcrumbsItem/BreadcrumbsItem.tsx
+++ b/packages/cre8-react/src/components/BreadcrumbsItem/BreadcrumbsItem.tsx
@@ -4,7 +4,7 @@ import { Cre8BreadcrumbsItem as Cre8BreadcrumbsItemElement } from '@cre8_dev/cre
 
 export const Cre8BreadcrumbsItem = createComponent({
     react: React,
-    tagName: 'Cre8-breadcrumbs-item',
+    tagName: 'cre8-breadcrumbs-item',
     elementClass: Cre8BreadcrumbsItemElement,
 
 });

--- a/packages/cre8-react/src/components/Button/Button.tsx
+++ b/packages/cre8-react/src/components/Button/Button.tsx
@@ -71,6 +71,6 @@ import React from 'react';
 
 export const Cre8Button = createComponent({
     react: React,
-    tagName: 'Cre8-button',
+    tagName: 'cre8-button',
     elementClass: Cre8ButtonElement,
 });

--- a/packages/cre8-react/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/cre8-react/src/components/ButtonGroup/ButtonGroup.tsx
@@ -4,7 +4,7 @@ import { Cre8ButtonGroup as Cre8ButtonGroupElement } from '@cre8_dev/cre8-wc/lib
 
 export const Cre8ButtonGroup = createComponent({
     react: React,
-    tagName: 'Cre8-button-group',
+    tagName: 'cre8-button-group',
     elementClass: Cre8ButtonGroupElement,
 
 });

--- a/packages/cre8-react/src/components/Card/Card.tsx
+++ b/packages/cre8-react/src/components/Card/Card.tsx
@@ -16,7 +16,7 @@ import { Cre8Card as Cre8CardElement } from '@cre8_dev/cre8-wc/lib/components/ca
 
 export const Cre8Card = createComponent({
     react: React,
-    tagName: 'Cre8-card',
+    tagName: 'cre8-card',
     elementClass: Cre8CardElement,
 
 });

--- a/packages/cre8-react/src/components/CheckboxField/CheckboxField.tsx
+++ b/packages/cre8-react/src/components/CheckboxField/CheckboxField.tsx
@@ -4,7 +4,7 @@ import { Cre8CheckboxField as Cre8CheckboxFieldElement } from '@cre8_dev/cre8-wc
 
 export const Cre8CheckboxField = createComponent({
     react: React,
-    tagName: 'Cre8-checkbox-field',
+    tagName: 'cre8-checkbox-field',
     elementClass: Cre8CheckboxFieldElement,
 
 });

--- a/packages/cre8-react/src/components/CheckboxFieldItem/CheckboxFieldItem.tsx
+++ b/packages/cre8-react/src/components/CheckboxFieldItem/CheckboxFieldItem.tsx
@@ -8,7 +8,7 @@ import { Cre8DomEvent } from '../../util/Cre8DomEvent';
  */
 export const Cre8CheckboxFieldItem = createComponent({
     react: React,
-    tagName: 'Cre8-checkbox-field-item',
+    tagName: 'cre8-checkbox-field-item',
     elementClass: Cre8CheckboxFieldItemElement,
     events: {
         onChange: 'input' as EventName<Cre8DomEvent<Cre8CheckboxFieldItemElement>>,

--- a/packages/cre8-react/src/components/DangerButton/DangerButton.tsx
+++ b/packages/cre8-react/src/components/DangerButton/DangerButton.tsx
@@ -4,7 +4,7 @@ import { Cre8DangerButton as Cre8DangerButtonElement } from '@cre8_dev/cre8-wc/l
 
 export const Cre8DangerButton = createComponent({
     react: React,
-    tagName: 'Cre8-danger-button',
+    tagName: 'cre8-danger-button',
     elementClass: Cre8DangerButtonElement,
 
 });

--- a/packages/cre8-react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/cre8-react/src/components/DatePicker/DatePicker.tsx
@@ -11,7 +11,7 @@ import { Cre8DomEvent } from '../../util/Cre8DomEvent';
 
 export const Cre8DatePicker = createComponent({
     react: React,
-    tagName: 'Cre8-date-picker',
+    tagName: 'cre8-date-picker',
     elementClass: Cre8DatePickerElement,
     events: {
         onChange: 'input' as EventName<Cre8DomEvent<Cre8DatePickerElement>>,

--- a/packages/cre8-react/src/components/Divider/Divider.tsx
+++ b/packages/cre8-react/src/components/Divider/Divider.tsx
@@ -16,6 +16,6 @@ import { Cre8Divider as Cre8DividerElement } from '@cre8_dev/cre8-wc/lib/compone
 
 export const Cre8Divider = createComponent({
     react: React,
-    tagName: 'Cre8-divider',
+    tagName: 'cre8-divider',
     elementClass: Cre8DividerElement,
 });

--- a/packages/cre8-react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/cre8-react/src/components/Dropdown/Dropdown.tsx
@@ -9,7 +9,7 @@ import { Cre8DomEvent } from '../../util/Cre8DomEvent';
  */
 export const Cre8Dropdown = createComponent({
     react: React,
-    tagName: 'Cre8-dropdown',
+    tagName: 'cre8-dropdown',
     elementClass: Cre8DropdownElement,
     events: {
         onDropdownItemSelected: 'dropdown-item-selected' as EventName<Cre8DomEvent<Cre8DropdownItemElement, Cre8DropdownElement>>,

--- a/packages/cre8-react/src/components/DropdownItem/DropdownItem.tsx
+++ b/packages/cre8-react/src/components/DropdownItem/DropdownItem.tsx
@@ -10,7 +10,7 @@ import { Cre8DomEvent } from '../../util/Cre8DomEvent';
  */
 export const Cre8DropdownItem = createComponent({
     react: React,
-    tagName: 'Cre8-dropdown-item',
+    tagName: 'cre8-dropdown-item',
     elementClass: Cre8DropdownItemElement,
     events: {
         onDropdownItemSelected: 'dropdown-item-selected' as EventName<Cre8DomEvent<Cre8DropdownItemElement>>,

--- a/packages/cre8-react/src/components/Feature/Feature.tsx
+++ b/packages/cre8-react/src/components/Feature/Feature.tsx
@@ -4,7 +4,7 @@ import { Cre8Feature as Cre8FeatureElement } from '@cre8_dev/cre8-wc/lib/compone
 
 export const Cre8Feature = createComponent({
     react: React,
-    tagName: 'Cre8-feature',
+    tagName: 'cre8-feature',
     elementClass: Cre8FeatureElement,
 
 });

--- a/packages/cre8-react/src/components/Field/Field.tsx
+++ b/packages/cre8-react/src/components/Field/Field.tsx
@@ -9,7 +9,7 @@ import { Cre8DomEvent } from '../../util/Cre8DomEvent';
  */
 export const Cre8Field = createComponent({
     react: React,
-    tagName: 'Cre8-field',
+    tagName: 'cre8-field',
     elementClass: Cre8FieldElement,
     events: {
         onChange: 'input' as EventName<Cre8DomEvent<Cre8FieldElement>>,

--- a/packages/cre8-react/src/components/FieldNote/FieldNote.tsx
+++ b/packages/cre8-react/src/components/FieldNote/FieldNote.tsx
@@ -9,7 +9,7 @@ import { Cre8FieldNote as Cre8FieldNoteElement } from '@cre8_dev/cre8-wc/lib/com
 
 export const Cre8FieldNote = createComponent({
     react: React,
-    tagName: 'Cre8-field-note',
+    tagName: 'cre8-field-note',
     elementClass: Cre8FieldNoteElement,
 
 });

--- a/packages/cre8-react/src/components/Footer/Footer.tsx
+++ b/packages/cre8-react/src/components/Footer/Footer.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const Cre8Footer = createComponent({
     react: React,
-    tagName: 'Cre8-footer',
+    tagName: 'cre8-footer',
     elementClass: Cre8FooterElement,
 });

--- a/packages/cre8-react/src/components/GlobalNav/GlobalNav.tsx
+++ b/packages/cre8-react/src/components/GlobalNav/GlobalNav.tsx
@@ -4,7 +4,7 @@ import { Cre8GlobalNav as Cre8GlobalNavElement } from '@cre8_dev/cre8-wc/lib/com
 
 export const Cre8GlobalNav = createComponent({
     react: React,
-    tagName: 'Cre8-global-nav',
+    tagName: 'cre8-global-nav',
     elementClass: Cre8GlobalNavElement,
 
 });

--- a/packages/cre8-react/src/components/GlobalNavItem/GlobalNavItem.tsx
+++ b/packages/cre8-react/src/components/GlobalNavItem/GlobalNavItem.tsx
@@ -4,7 +4,7 @@ import { Cre8GlobalNavItem as Cre8GlobalNavItemElement } from '@cre8_dev/cre8-wc
 
 export const Cre8GlobalNavItem = createComponent({
     react: React,
-    tagName: 'Cre8-global-nav-item',
+    tagName: 'cre8-global-nav-item',
     elementClass: Cre8GlobalNavItemElement,
 
 });

--- a/packages/cre8-react/src/components/Grid/Grid.tsx
+++ b/packages/cre8-react/src/components/Grid/Grid.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const Cre8Grid = createComponent({
     react: React,
-    tagName: 'Cre8-grid',
+    tagName: 'cre8-grid',
     elementClass: Cre8GridElement,
 });

--- a/packages/cre8-react/src/components/GridItem/GridItem.tsx
+++ b/packages/cre8-react/src/components/GridItem/GridItem.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const Cre8GridItem = createComponent({
     react: React,
-    tagName: 'Cre8-grid-item',
+    tagName: 'cre8-grid-item',
     elementClass: Cre8GridItemElement,
 });

--- a/packages/cre8-react/src/components/Header/Header.tsx
+++ b/packages/cre8-react/src/components/Header/Header.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const Cre8Header = createComponent({
     react: React,
-    tagName: 'Cre8-header',
+    tagName: 'cre8-header',
     elementClass: Cre8HeaderElement,
 });

--- a/packages/cre8-react/src/components/Heading/Heading.tsx
+++ b/packages/cre8-react/src/components/Heading/Heading.tsx
@@ -19,6 +19,6 @@ import React from 'react';
 
 export const Cre8Heading = createComponent({
     react: React,
-    tagName: 'Cre8-heading',
+    tagName: 'cre8-heading',
     elementClass: Cre8HeadingElement,
 });

--- a/packages/cre8-react/src/components/Hero/Hero.tsx
+++ b/packages/cre8-react/src/components/Hero/Hero.tsx
@@ -4,7 +4,7 @@ import { Cre8Hero as Cre8HeroElement } from '@cre8_dev/cre8-wc/lib/components/he
 
 export const Cre8Hero = createComponent({
     react: React,
-    tagName: 'Cre8-hero',
+    tagName: 'cre8-hero',
     elementClass: Cre8HeroElement,
 
 });

--- a/packages/cre8-react/src/components/Icon/Icon.tsx
+++ b/packages/cre8-react/src/components/Icon/Icon.tsx
@@ -36,6 +36,6 @@ import React from 'react';
 
 export const Cre8IconLegacy = createComponent({
     react: React,
-    tagName: 'Cre8-icon-legacy',
+    tagName: 'cre8-icon-legacy',
     elementClass: Cre8IconLegacyElement,
 });

--- a/packages/cre8-react/src/components/InlineAlert/InlineAlert.tsx
+++ b/packages/cre8-react/src/components/InlineAlert/InlineAlert.tsx
@@ -10,6 +10,6 @@ import { Cre8InlineAlert as Cre8InlineAlertElement } from '@cre8_dev/cre8-wc/lib
 
 export const Cre8InlineAlert = createComponent({
     react: React,
-    tagName: 'Cre8-inline-alert',
+    tagName: 'cre8-inline-alert',
     elementClass: Cre8InlineAlertElement,
 });

--- a/packages/cre8-react/src/components/Layout/Layout.tsx
+++ b/packages/cre8-react/src/components/Layout/Layout.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const Cre8Layout = createComponent({
     react: React,
-    tagName: 'Cre8-layout',
+    tagName: 'cre8-layout',
     elementClass: Cre8LayoutElement,
 });

--- a/packages/cre8-react/src/components/LayoutContainer/LayoutContainer.tsx
+++ b/packages/cre8-react/src/components/LayoutContainer/LayoutContainer.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const Cre8LayoutContainer = createComponent({
     react: React,
-    tagName: 'Cre8-layout-container',
+    tagName: 'cre8-layout-container',
     elementClass: Cre8LayoutContainerElement,
 });

--- a/packages/cre8-react/src/components/LayoutSection/LayoutSection.tsx
+++ b/packages/cre8-react/src/components/LayoutSection/LayoutSection.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const Cre8LayoutSection = createComponent({
     react: React,
-    tagName: 'Cre8-layout-section',
+    tagName: 'cre8-layout-section',
     elementClass: Cre8LayoutSectionElement,
 });

--- a/packages/cre8-react/src/components/LinelengthContainer/LinelengthContainer.tsx
+++ b/packages/cre8-react/src/components/LinelengthContainer/LinelengthContainer.tsx
@@ -4,7 +4,7 @@ import { Cre8LinelengthContainer as Cre8LinelengthContainerElement } from '@cre8
 
 export const Cre8LinelengthContainer = createComponent({
     react: React,
-    tagName: 'Cre8-linelength-container',
+    tagName: 'cre8-linelength-container',
     elementClass: Cre8LinelengthContainerElement,
 
 });

--- a/packages/cre8-react/src/components/Link/Link.tsx
+++ b/packages/cre8-react/src/components/Link/Link.tsx
@@ -19,7 +19,7 @@ import { Cre8Link as Cre8LinkElement } from '@cre8_dev/cre8-wc/lib/components/li
 
 export const Cre8Link = createComponent({
     react: React,
-    tagName: 'Cre8-link',
+    tagName: 'cre8-link',
     elementClass: Cre8LinkElement,
 
 });

--- a/packages/cre8-react/src/components/LinkList/LinkList.tsx
+++ b/packages/cre8-react/src/components/LinkList/LinkList.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const Cre8LinkList = createComponent({
     react: React,
-    tagName: 'Cre8-link-list',
+    tagName: 'cre8-link-list',
     elementClass: Cre8LinkListElement,
 });

--- a/packages/cre8-react/src/components/LinkListItem/LinkListItem.tsx
+++ b/packages/cre8-react/src/components/LinkListItem/LinkListItem.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const Cre8LinkListItem = createComponent({
     react: React,
-    tagName: 'Cre8-link-list-item',
+    tagName: 'cre8-link-list-item',
     elementClass: Cre8LinkListItemElement,
 });

--- a/packages/cre8-react/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/packages/cre8-react/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -38,7 +38,7 @@ import { Cre8LoadingSpinner as Cre8LoadingSpinnerElement } from '@cre8_dev/cre8-
  */
 export const Cre8LoadingSpinner = createComponent({
     react: React,
-    tagName: 'Cre8-loading-spinner',
+    tagName: 'cre8-loading-spinner',
     elementClass: Cre8LoadingSpinnerElement,
 
 });

--- a/packages/cre8-react/src/components/Logo/Logo.tsx
+++ b/packages/cre8-react/src/components/Logo/Logo.tsx
@@ -4,7 +4,7 @@ import { Cre8Logo as Cre8LogoElement } from '@cre8_dev/cre8-wc/lib/components/lo
 
 export const Cre8Logo = createComponent({
     react: React,
-    tagName: 'Cre8-logo',
+    tagName: 'cre8-logo',
     elementClass: Cre8LogoElement,
 
 });

--- a/packages/cre8-react/src/components/Main/Main.tsx
+++ b/packages/cre8-react/src/components/Main/Main.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const Cre8Main = createComponent({
     react: React,
-    tagName: 'Cre8-main',
+    tagName: 'cre8-main',
     elementClass: Cre8MainElement,
 });

--- a/packages/cre8-react/src/components/Modal/Modal.tsx
+++ b/packages/cre8-react/src/components/Modal/Modal.tsx
@@ -4,7 +4,7 @@ import { Cre8Modal as Cre8ModalElement, type CloseModalEvent } from '@cre8_dev/c
 
 export const Cre8Modal = createComponent({
     react: React,
-    tagName: 'Cre8-modal',
+    tagName: 'cre8-modal',
     elementClass: Cre8ModalElement,
     events: {
          /** Event emitted when the close button is clicked. Use this

--- a/packages/cre8-react/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/cre8-react/src/components/MultiSelect/MultiSelect.tsx
@@ -15,7 +15,7 @@ import { Cre8DomEvent } from '../../util/Cre8DomEvent';
 
 export const Cre8MultiSelect = createComponent({
     react: React,
-    tagName: 'Cre8-multi-select',
+    tagName: 'cre8-multi-select',
     elementClass: Cre8MultiSelectElement,
     events: {
         onSelectedItemsChange: 'selectedItemsChange' as EventName<Cre8DomEvent<Cre8MultiSelectElement>>,

--- a/packages/cre8-react/src/components/NavContainer/NavContainer.tsx
+++ b/packages/cre8-react/src/components/NavContainer/NavContainer.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const Cre8NavContainer = createComponent({
     react: React,
-    tagName: 'Cre8-nav-container',
+    tagName: 'cre8-nav-container',
     elementClass: Cre8NavContainerElement,
 });

--- a/packages/cre8-react/src/components/Pagination/Pagination.tsx
+++ b/packages/cre8-react/src/components/Pagination/Pagination.tsx
@@ -48,6 +48,6 @@ import { Cre8Pagination as Cre8PaginationElement } from '@cre8_dev/cre8-wc/lib/c
 
 export const Cre8Pagination = createComponent({
     react: React,
-    tagName: 'Cre8-pagination',
+    tagName: 'cre8-pagination',
     elementClass: Cre8PaginationElement,
 });

--- a/packages/cre8-react/src/components/PercentBar/PercentBar.tsx
+++ b/packages/cre8-react/src/components/PercentBar/PercentBar.tsx
@@ -12,7 +12,7 @@ import { Cre8DomEvent } from '../../util/Cre8DomEvent';
 
 export const Cre8PercentBar = createComponent({
     react: React,
-    tagName: 'Cre8-percent-bar',
+    tagName: 'cre8-percent-bar',
     elementClass: Cre8PercentBarElement,
     events: {
         onLeftActionButtonClick: 'leftActionButtonClick' as EventName<Cre8DomEvent<Cre8PercentBarElement>>,

--- a/packages/cre8-react/src/components/Popover/Popover.tsx
+++ b/packages/cre8-react/src/components/Popover/Popover.tsx
@@ -10,7 +10,7 @@ import { Cre8DomEvent } from '../../util/Cre8DomEvent';
 
 export const Cre8Popover = createComponent({
     react: React,
-    tagName: 'Cre8-popover',
+    tagName: 'cre8-popover',
     elementClass: Cre8PopoverElement,
     events: {
         onOpen: 'open' as EventName<Cre8DomEvent<Cre8PopoverElement>>,

--- a/packages/cre8-react/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/cre8-react/src/components/PrimaryNav/PrimaryNav.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const Cre8PrimaryNav = createComponent({
     react: React,
-    tagName: 'Cre8-primary-nav',
+    tagName: 'cre8-primary-nav',
     elementClass: Cre8PrimaryNavElement,
 });

--- a/packages/cre8-react/src/components/PrimaryNavItem/PrimaryNavItem.tsx
+++ b/packages/cre8-react/src/components/PrimaryNavItem/PrimaryNavItem.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const Cre8PrimaryNavItem = createComponent({
     react: React,
-    tagName: 'Cre8-primary-nav-item',
+    tagName: 'cre8-primary-nav-item',
     elementClass: Cre8PrimaryNavItemElement,
 });

--- a/packages/cre8-react/src/components/ProgressMeter/ProgressMeter.tsx
+++ b/packages/cre8-react/src/components/ProgressMeter/ProgressMeter.tsx
@@ -12,7 +12,7 @@ import { Cre8ProgressMeter as Cre8ProgressMeterElement } from '@cre8_dev/cre8-wc
  */
 export const Cre8ProgressMeter = createComponent({
     react: React,
-    tagName: 'Cre8-progress-meter',
+    tagName: 'cre8-progress-meter',
     elementClass: Cre8ProgressMeterElement,
 
 });

--- a/packages/cre8-react/src/components/ProgressSteps/ProgressSteps.tsx
+++ b/packages/cre8-react/src/components/ProgressSteps/ProgressSteps.tsx
@@ -25,7 +25,7 @@ import { Cre8ProgressSteps as Cre8ProgressStepsElement } from '@cre8_dev/cre8-wc
  */
 export const Cre8ProgressSteps = createComponent({
     react: React,
-    tagName: 'Cre8-progress-steps',
+    tagName: 'cre8-progress-steps',
     elementClass: Cre8ProgressStepsElement,
 
 });

--- a/packages/cre8-react/src/components/ProgressStepsItem/ProgressStepsItem.tsx
+++ b/packages/cre8-react/src/components/ProgressStepsItem/ProgressStepsItem.tsx
@@ -18,7 +18,7 @@ import { Cre8ProgressStepsItem as Cre8ProgressStepsItemElement } from '@cre8_dev
  */
 export const Cre8ProgressStepsItem = createComponent({
     react: React,
-    tagName: 'Cre8-progress-steps-item',
+    tagName: 'cre8-progress-steps-item',
     elementClass: Cre8ProgressStepsItemElement,
 
 });

--- a/packages/cre8-react/src/components/RadioField/RadioField.tsx
+++ b/packages/cre8-react/src/components/RadioField/RadioField.tsx
@@ -11,7 +11,7 @@ import { Cre8RadioField as Cre8RadioFieldElement } from '@cre8_dev/cre8-wc/lib/c
  */
 export const Cre8RadioField = createComponent({
     react: React,
-    tagName: 'Cre8-radio-field',
+    tagName: 'cre8-radio-field',
     elementClass: Cre8RadioFieldElement,
 
 });

--- a/packages/cre8-react/src/components/RadioFieldItem/RadioFieldItem.tsx
+++ b/packages/cre8-react/src/components/RadioFieldItem/RadioFieldItem.tsx
@@ -10,7 +10,7 @@ import { Cre8DomEvent } from '../../util/Cre8DomEvent';
  */
 export const Cre8RadioFieldItem = createComponent({
     react: React,
-    tagName: 'Cre8-radio-field-item',
+    tagName: 'cre8-radio-field-item',
     elementClass: Cre8RadioFieldItemElement,
     events: {
         onChange: 'input' as EventName<Cre8DomEvent<Cre8RadioFieldItemElement>>,

--- a/packages/cre8-react/src/components/RemoveTag/RemoveTag.tsx
+++ b/packages/cre8-react/src/components/RemoveTag/RemoveTag.tsx
@@ -5,7 +5,7 @@ import { Cre8DomEvent } from '../../util/Cre8DomEvent';
 
 export const Cre8RemoveTag = createComponent({
     react: React,
-    tagName: 'Cre8-remove-tag',
+    tagName: 'cre8-remove-tag',
     elementClass: Cre8RemoveTagElement,
     events: {
         onRemoveTagClicked: 'removeTagClicked' as EventName<Cre8DomEvent<Cre8RemoveTagElement>>,

--- a/packages/cre8-react/src/components/Section/Section.tsx
+++ b/packages/cre8-react/src/components/Section/Section.tsx
@@ -4,7 +4,7 @@ import { Cre8Section as Cre8SectionElement } from '@cre8_dev/cre8-wc/lib/compone
 
 export const Cre8Section = createComponent({
     react: React,
-    tagName: 'Cre8-section',
+    tagName: 'cre8-section',
     elementClass: Cre8SectionElement,
 
 });

--- a/packages/cre8-react/src/components/Select/Select.tsx
+++ b/packages/cre8-react/src/components/Select/Select.tsx
@@ -30,7 +30,7 @@ import { type Cre8DomEvent } from '../../util/Cre8DomEvent';
 
 export const Cre8Select = createComponent({
     react: React,
-    tagName: 'Cre8-select',
+    tagName: 'cre8-select',
     elementClass: Cre8SelectElement,
     events: {
         onChange: 'change' as EventName<Cre8DomEvent<Cre8SelectElement>>,

--- a/packages/cre8-react/src/components/SelectTile/SelectTile.tsx
+++ b/packages/cre8-react/src/components/SelectTile/SelectTile.tsx
@@ -5,7 +5,7 @@ import { Cre8DomEvent } from '../../util/Cre8DomEvent';
 
 export const Cre8SelectTile = createComponent({
     react: React,
-    tagName: 'Cre8-select-tile',
+    tagName: 'cre8-select-tile',
     elementClass: Cre8SelectTileElement,
     events: {
         onBlur: 'blur' as EventName<Cre8DomEvent<Cre8SelectTileElement> & FocusEvent>,

--- a/packages/cre8-react/src/components/SelectTileList/SelectTileList.tsx
+++ b/packages/cre8-react/src/components/SelectTileList/SelectTileList.tsx
@@ -4,7 +4,7 @@ import { Cre8SelectTileList as Cre8SelectTileListElement } from '@cre8_dev/cre8-
 
 export const Cre8SelectTileList = createComponent({
     react: React,
-    tagName: 'Cre8-select-tile-list',
+    tagName: 'cre8-select-tile-list',
     elementClass: Cre8SelectTileListElement,
 
 });

--- a/packages/cre8-react/src/components/SkeletonLoader/SkeletonLoader.tsx
+++ b/packages/cre8-react/src/components/SkeletonLoader/SkeletonLoader.tsx
@@ -25,6 +25,6 @@ import { Cre8SkeletonLoader as Cre8SkeletonLoaderElement } from '@cre8_dev/cre8-
 
 export const Cre8SkeletonLoader = createComponent({
     react: React,
-    tagName: 'Cre8-skeleton-loader',
+    tagName: 'cre8-skeleton-loader',
     elementClass: Cre8SkeletonLoaderElement,
 });

--- a/packages/cre8-react/src/components/SplitButton/SplitButton.tsx
+++ b/packages/cre8-react/src/components/SplitButton/SplitButton.tsx
@@ -4,7 +4,7 @@ import { Cre8SplitButton as Cre8SplitButtonElement } from '@cre8_dev/cre8-wc/lib
 
 export const Cre8SplitButton = createComponent({
     react: React,
-    tagName: 'Cre8-split-button',
+    tagName: 'cre8-split-button',
     elementClass: Cre8SplitButtonElement,
 
 });

--- a/packages/cre8-react/src/components/Submenu/Submenu.tsx
+++ b/packages/cre8-react/src/components/Submenu/Submenu.tsx
@@ -4,7 +4,7 @@ import { Cre8Submenu as Cre8SubmenuElement } from '@cre8_dev/cre8-wc/lib/compone
 
 export const Cre8Submenu = createComponent({
     react: React,
-    tagName: 'Cre8-submenu',
+    tagName: 'cre8-submenu',
     elementClass: Cre8SubmenuElement,
 
 });

--- a/packages/cre8-react/src/components/SubmenuItem/SubmenuItem.tsx
+++ b/packages/cre8-react/src/components/SubmenuItem/SubmenuItem.tsx
@@ -4,7 +4,7 @@ import { Cre8SubmenuItem as Cre8SubmenuItemElement } from '@cre8_dev/cre8-wc/lib
 
 export const Cre8SubmenuItem = createComponent({
     react: React,
-    tagName: 'Cre8-submenu-item',
+    tagName: 'cre8-submenu-item',
     elementClass: Cre8SubmenuItemElement,
 
 });

--- a/packages/cre8-react/src/components/Tab/Tab.tsx
+++ b/packages/cre8-react/src/components/Tab/Tab.tsx
@@ -4,6 +4,6 @@ import { Cre8Tab as Cre8TabElement } from '@cre8_dev/cre8-wc/lib/components/tab/
 
 export const Cre8Tab = createComponent({
     react: React,
-    tagName: 'Cre8-tab',
+    tagName: 'cre8-tab',
     elementClass: Cre8TabElement,
 });

--- a/packages/cre8-react/src/components/TabPanel/TabPanel.tsx
+++ b/packages/cre8-react/src/components/TabPanel/TabPanel.tsx
@@ -4,6 +4,6 @@ import { Cre8TabPanel as Cre8TabPanelElement } from '@cre8_dev/cre8-wc/lib/compo
 
 export const Cre8TabPanel = createComponent({
     react: React,
-    tagName: 'Cre8-tab-panel',
+    tagName: 'cre8-tab-panel',
     elementClass: Cre8TabPanelElement,
 });

--- a/packages/cre8-react/src/components/Table/Table.tsx
+++ b/packages/cre8-react/src/components/Table/Table.tsx
@@ -4,7 +4,7 @@ import { Cre8Table as Cre8TableElement } from '@cre8_dev/cre8-wc/lib/components/
 
 export const Cre8Table = createComponent({
     react: React,
-    tagName: 'Cre8-table',
+    tagName: 'cre8-table',
     elementClass: Cre8TableElement,
 
 });

--- a/packages/cre8-react/src/components/TableBody/TableBody.tsx
+++ b/packages/cre8-react/src/components/TableBody/TableBody.tsx
@@ -4,7 +4,7 @@ import { Cre8TableBody as Cre8TableBodyElement } from '@cre8_dev/cre8-wc/lib/com
 
 export const Cre8TableBody = createComponent({
     react: React,
-    tagName: 'Cre8-table-body',
+    tagName: 'cre8-table-body',
     elementClass: Cre8TableBodyElement,
 
 });

--- a/packages/cre8-react/src/components/TableCell/TableCell.tsx
+++ b/packages/cre8-react/src/components/TableCell/TableCell.tsx
@@ -4,7 +4,7 @@ import { Cre8TableCell as Cre8TableCellElement } from '@cre8_dev/cre8-wc/lib/com
 
 export const Cre8TableCell = createComponent({
     react: React,
-    tagName: 'Cre8-table-cell',
+    tagName: 'cre8-table-cell',
     elementClass: Cre8TableCellElement,
 
 });

--- a/packages/cre8-react/src/components/TableHeader/TableHeader.tsx
+++ b/packages/cre8-react/src/components/TableHeader/TableHeader.tsx
@@ -4,7 +4,7 @@ import { Cre8TableHeader as Cre8TableHeaderElement } from '@cre8_dev/cre8-wc/lib
 
 export const Cre8TableHeader = createComponent({
     react: React,
-    tagName: 'Cre8-table-header',
+    tagName: 'cre8-table-header',
     elementClass: Cre8TableHeaderElement,
 
 });

--- a/packages/cre8-react/src/components/TableHeaderCell/TableHeaderCell.tsx
+++ b/packages/cre8-react/src/components/TableHeaderCell/TableHeaderCell.tsx
@@ -4,7 +4,7 @@ import { Cre8TableHeaderCell as Cre8TableHeaderCellElement } from '@cre8_dev/cre
 
 export const Cre8TableHeaderCell = createComponent({
     react: React,
-    tagName: 'Cre8-table-header-cell',
+    tagName: 'cre8-table-header-cell',
     elementClass: Cre8TableHeaderCellElement,
 
 });

--- a/packages/cre8-react/src/components/TableObject/TableObject.tsx
+++ b/packages/cre8-react/src/components/TableObject/TableObject.tsx
@@ -4,7 +4,7 @@ import { Cre8TableObject as Cre8TableObjectElement } from '@cre8_dev/cre8-wc/lib
 
 export const Cre8TableObject = createComponent({
     react: React,
-    tagName: 'Cre8-table-object',
+    tagName: 'cre8-table-object',
     elementClass: Cre8TableObjectElement,
 
 });

--- a/packages/cre8-react/src/components/TableRow/TableRow.tsx
+++ b/packages/cre8-react/src/components/TableRow/TableRow.tsx
@@ -4,7 +4,7 @@ import { Cre8TableRow as Cre8TableRowElement } from '@cre8_dev/cre8-wc/lib/compo
 
 export const Cre8TableRow = createComponent({
     react: React,
-    tagName: 'Cre8-table-row',
+    tagName: 'cre8-table-row',
     elementClass: Cre8TableRowElement,
 
 });

--- a/packages/cre8-react/src/components/Tabs/Tabs.tsx
+++ b/packages/cre8-react/src/components/Tabs/Tabs.tsx
@@ -26,7 +26,7 @@ import { Cre8DomEvent } from '../../util/Cre8DomEvent';
 
 export const Cre8Tabs = createComponent({
     react: React,
-    tagName: 'Cre8-tabs',
+    tagName: 'cre8-tabs',
     elementClass: Cre8TabsElement,
     events: {
         onTabChange: 'tabChange' as EventName<Cre8DomEvent<Cre8TabsElement>>,

--- a/packages/cre8-react/src/components/Tag/Tag.tsx
+++ b/packages/cre8-react/src/components/Tag/Tag.tsx
@@ -18,7 +18,7 @@ import { Cre8DomEvent } from '../../util/Cre8DomEvent';
 
 export const Cre8Tag = createComponent({
     react: React,
-    tagName: 'Cre8-tag',
+    tagName: 'cre8-tag',
     elementClass: Cre8TagElement,
     events: {
         onChange: 'input' as EventName<Cre8DomEvent<Cre8TagElement>>,

--- a/packages/cre8-react/src/components/TagList/TagList.tsx
+++ b/packages/cre8-react/src/components/TagList/TagList.tsx
@@ -9,6 +9,6 @@ import { Cre8TagList as Cre8TagListElement } from '@cre8_dev/cre8-wc/lib/compone
  */
 export const Cre8TagList = createComponent({
     react: React,
-    tagName: 'Cre8-tag-list',
+    tagName: 'cre8-tag-list',
     elementClass: Cre8TagListElement,
 });

--- a/packages/cre8-react/src/components/TertiaryNav/TertiaryNav.tsx
+++ b/packages/cre8-react/src/components/TertiaryNav/TertiaryNav.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const Cre8TertiaryNav = createComponent({
     react: React,
-    tagName: 'Cre8-tertiary-nav',
+    tagName: 'cre8-tertiary-nav',
     elementClass: Cre8TertiaryNavElement,
 });

--- a/packages/cre8-react/src/components/TertiaryNavItem/TertiaryNavItem.tsx
+++ b/packages/cre8-react/src/components/TertiaryNavItem/TertiaryNavItem.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const Cre8TertiaryNavItem = createComponent({
     react: React,
-    tagName: 'Cre8-tertiary-nav-item',
+    tagName: 'cre8-tertiary-nav-item',
     elementClass: Cre8TertiaryNavItemElement,
 });

--- a/packages/cre8-react/src/components/TextLink/TextLink.tsx
+++ b/packages/cre8-react/src/components/TextLink/TextLink.tsx
@@ -4,7 +4,7 @@ import { Cre8TextLink as Cre8TextLinkElement } from '@cre8_dev/cre8-wc/lib/compo
 
 export const Cre8TextLink = createComponent({
     react: React,
-    tagName: 'Cre8-text-link',
+    tagName: 'cre8-text-link',
     elementClass: Cre8TextLinkElement,
 
 });

--- a/packages/cre8-react/src/components/TextPassage/TextPassage.tsx
+++ b/packages/cre8-react/src/components/TextPassage/TextPassage.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const Cre8TextPassage = createComponent({
     react: React,
-    tagName: 'Cre8-text-passage',
+    tagName: 'cre8-text-passage',
     elementClass: Cre8TextPassageElement,
 });

--- a/packages/cre8-react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/cre8-react/src/components/Tooltip/Tooltip.tsx
@@ -39,7 +39,7 @@ import { Cre8DomEvent } from '../../util/Cre8DomEvent';
  */
 export const Cre8Tooltip = createComponent({
     react: React,
-    tagName: 'Cre8-tooltip',
+    tagName: 'cre8-tooltip',
     elementClass: Cre8TooltipElement,
     events: {
         onOpen: 'open' as EventName<Cre8DomEvent<Cre8TooltipElement>>,

--- a/packages/cre8-react/src/components/UtilityNav/UtilityNav.tsx
+++ b/packages/cre8-react/src/components/UtilityNav/UtilityNav.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const Cre8UtilityNav = createComponent({
     react: React,
-    tagName: 'Cre8-utility-nav',
+    tagName: 'cre8-utility-nav',
     elementClass: Cre8UtilityNavElement,
 });

--- a/packages/cre8-react/src/components/UtilityNavItem/UtilityNavItem.tsx
+++ b/packages/cre8-react/src/components/UtilityNavItem/UtilityNavItem.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const Cre8UtilityNavItem = createComponent({
     react: React,
-    tagName: 'Cre8-utility-nav-item',
+    tagName: 'cre8-utility-nav-item',
     elementClass: Cre8UtilityNavItemElement,
 });

--- a/packages/cre8-react/src/components/VerticalCard/VerticalCard.tsx
+++ b/packages/cre8-react/src/components/VerticalCard/VerticalCard.tsx
@@ -4,6 +4,6 @@ import React from 'react';
 
 export const Cre8VerticalCard = createComponent({
     react: React,
-    tagName: 'Cre8-vertical-card',
+    tagName: 'cre8-vertical-card',
     elementClass: Cre8VerticalCardElement,
 });


### PR DESCRIPTION
## Summary
- react wrappers should use lowercase element names
- fix tag names to match Web Component registrations

## Testing
- `pnpm cre8-wc:test` *(fails: Command "workspace" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68465179e29c8321a2915c1432d7c347