### PR TITLE
Add A2UI demo workspace with brand theming and pattern library

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,13 @@
     "publish:react": "pnpm --filter @tmorrow/cre8-wc publish:react",
     "storybook": "pnpm --filter @tmorrow/cre8-wc storybook",
     "storybook:react": "pnpm --filter @tmorrow/cre8-wc storybook:react",
-    "test": "pnpm --filter @tmorrow/cre8-wc test"
+    "test": "pnpm --filter @tmorrow/cre8-wc test",
+    "mcp:api": "pnpm --filter @tmorrow/cre8-mcp dev:api",
+    "studio": "pnpm --filter @tmorrow/cre8-studio dev",
+    "studio:full": "concurrently -k -n mcp,studio -c magenta,cyan \"pnpm mcp:api\" \"pnpm studio\""
+  },
+  "devDependencies": {
+    "concurrently": "^9.1.2"
   },
   "engines": {
     "node": ">=20",

--- a/packages/cre8-studio/.env.example
+++ b/packages/cre8-studio/.env.example
@@ -16,3 +16,13 @@
 # NEXT_PUBLIC_DATA_AGENT_URL=http://localhost:8002
 # Set API_TOKEN in the agent's env, then mirror it here to enable auth
 # NEXT_PUBLIC_DATA_AGENT_TOKEN=
+
+# --- cre8-mcp (A2UI validation) ---
+# render_ui specs are validated against the canonical cre8-mcp HTTP API.
+# Start it with: pnpm --filter @tmorrow/cre8-mcp build && pnpm --filter @tmorrow/cre8-mcp start:api
+# URL of the cre8-mcp API (defaults to http://localhost:3001)
+# CRE8_MCP_URL=http://localhost:3001
+# Set to 0 to skip the MCP and validate in-process only (uses the same validator)
+# CRE8_MCP_VALIDATE=1
+# Per-request timeout (ms) before falling back to local validation
+# CRE8_MCP_TIMEOUT_MS=2000

--- a/packages/cre8-studio/next.config.ts
+++ b/packages/cre8-studio/next.config.ts
@@ -1,8 +1,22 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const config: NextConfig = {
   transpilePackages: ["@tmorrow/cre8-wc"],
   serverExternalPackages: ["esbuild"],
+  // Monorepo: trace from the repo root so serverless functions bundle the
+  // sibling cre8-wc assets the API routes read at runtime (tokens, a2ui catalog
+  // + examples, cdn bundle). Keys are route paths; globs are relative to this
+  // package dir.
+  outputFileTracingRoot: path.join(process.cwd(), "..", ".."),
+  outputFileTracingIncludes: {
+    "/api/cre8-wc-cdn": ["../cre8-wc/cdn/cre8-wc.esm.js"],
+    "/api/cre8-wc-tokens": ["../cre8-wc/design-tokens/brands/cre8-a2ui/css/**"],
+    "/api/brand-extract": ["../cre8-wc/design-tokens/brands/cre8-a2ui/css/**"],
+    "/api/a2ui-patterns": ["../cre8-wc/a2ui/examples/**"],
+    "/api/a2ui-runtime": ["../cre8-wc/a2ui/**", "../cre8-wc/cdn/cre8-wc.esm.js"],
+    "/api/explore-report": ["../cre8-wc/cdn/cre8-wc.esm.js"],
+  },
   turbopack: {
     rules: {
       "*.svg?raw": { loaders: ["raw-loader"], as: "*.js" },

--- a/packages/cre8-studio/package.json
+++ b/packages/cre8-studio/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",
+    "prebuild": "node scripts/prepare-cre8wc.mjs",
     "build": "next build",
+    "vercel-build": "node scripts/prepare-cre8wc.mjs && next build",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run"

--- a/packages/cre8-studio/scripts/prepare-cre8wc.mjs
+++ b/packages/cre8-studio/scripts/prepare-cre8wc.mjs
@@ -1,0 +1,27 @@
+// Ensure the cre8-wc design-token CSS the studio @imports is resolvable.
+//
+// globals.css imports `@tmorrow/cre8-wc/design-tokens/brands/.../tokens_cre8-a2ui.css`,
+// which the package export map maps to `lib/design-tokens/*`. That lib dir only
+// exists after a full cre8-wc build (`pnpm build:wc`). For a lightweight,
+// CI/Vercel-friendly build we just mirror the source design-tokens into lib —
+// it's the only part of cre8-wc the studio build needs.
+import { cpSync, existsSync, mkdirSync } from "fs";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const wc = resolve(here, "..", "..", "cre8-wc");
+const src = resolve(wc, "design-tokens");
+const dest = resolve(wc, "lib", "design-tokens");
+
+if (!existsSync(src)) {
+  console.error(`[prepare-cre8wc] source design-tokens not found at ${src}`);
+  process.exit(1);
+}
+if (existsSync(dest)) {
+  console.log("[prepare-cre8wc] lib/design-tokens already present — skipping");
+} else {
+  mkdirSync(dirname(dest), { recursive: true });
+  cpSync(src, dest, { recursive: true });
+  console.log("[prepare-cre8wc] mirrored design-tokens -> lib/design-tokens");
+}

--- a/packages/cre8-studio/src/app/a2ui/brand/page.tsx
+++ b/packages/cre8-studio/src/app/a2ui/brand/page.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+import BrandExtractor from "@/components/a2ui-demo/brand-extractor";
+
+export default function BrandPage() {
+  return (
+    <main className="a2ui-page">
+      <header className="header">
+        <h1>Connect your brand</h1>
+        <span className="subtitle">extract a palette → cre8 token overrides</span>
+        <Link href="/a2ui" className="header-nav-link">← A2UI</Link>
+        <Link href="/a2ui/workspace" className="header-nav-link">Workspace →</Link>
+      </header>
+      <BrandExtractor />
+    </main>
+  );
+}

--- a/packages/cre8-studio/src/app/a2ui/brand/page.tsx
+++ b/packages/cre8-studio/src/app/a2ui/brand/page.tsx
@@ -1,16 +1,9 @@
-import Link from "next/link";
 import BrandExtractor from "@/components/a2ui-demo/brand-extractor";
 
 export default function BrandPage() {
   return (
-    <main className="a2ui-page">
-      <header className="header">
-        <h1>Connect your brand</h1>
-        <span className="subtitle">extract a palette → cre8 token overrides</span>
-        <Link href="/a2ui" className="header-nav-link">← A2UI</Link>
-        <Link href="/a2ui/workspace" className="header-nav-link">Workspace →</Link>
-      </header>
+    <div className="page page--scroll">
       <BrandExtractor />
-    </main>
+    </div>
   );
 }

--- a/packages/cre8-studio/src/app/a2ui/layout.tsx
+++ b/packages/cre8-studio/src/app/a2ui/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import ThemeBoot from "@/components/a2ui-demo/theme-boot";
+
+export const metadata: Metadata = {
+  title: "cre8 A2UI",
+  description: "Connect your brand and build apps with cre8-wc + A2UI",
+};
+
+export default function A2uiLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <ThemeBoot />
+      {children}
+    </>
+  );
+}

--- a/packages/cre8-studio/src/app/a2ui/page.tsx
+++ b/packages/cre8-studio/src/app/a2ui/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export default function A2uiLanding() {
   return (
-    <main className="a2ui-landing">
+    <div className="page page--center a2ui-landing">
       <div className="a2ui-landing-inner">
         <header className="a2ui-landing-header">
           <span className="a2ui-eyebrow">cre8 · A2UI</span>
@@ -51,6 +51,6 @@ export default function A2uiLanding() {
           <span>Powered by cre8-wc + A2UI</span>
         </footer>
       </div>
-    </main>
+    </div>
   );
 }

--- a/packages/cre8-studio/src/app/a2ui/page.tsx
+++ b/packages/cre8-studio/src/app/a2ui/page.tsx
@@ -1,0 +1,56 @@
+import Link from "next/link";
+
+export default function A2uiLanding() {
+  return (
+    <main className="a2ui-landing">
+      <div className="a2ui-landing-inner">
+        <header className="a2ui-landing-header">
+          <span className="a2ui-eyebrow">cre8 · A2UI</span>
+          <h1>Build branded apps with agent-composed UI</h1>
+          <p>
+            Connect your brand to retheme the entire cre8 component system, then
+            open a workspace where an agent assembles real cre8-wc interfaces from
+            your patterns, components and data.
+          </p>
+        </header>
+
+        <div className="a2ui-choice-grid">
+          <Link href="/a2ui/brand" className="a2ui-choice-card">
+            <div className="a2ui-choice-icon" aria-hidden>
+              <span className="swatch s1" />
+              <span className="swatch s2" />
+              <span className="swatch s3" />
+            </div>
+            <h2>Connect your brand</h2>
+            <p>
+              Point at a website or pick a color. We extract a palette and font and
+              generate cre8 design-token overrides — every component instantly
+              themed.
+            </p>
+            <span className="a2ui-choice-cta">Open brand extractor →</span>
+          </Link>
+
+          <Link href="/a2ui/workspace" className="a2ui-choice-card">
+            <div className="a2ui-choice-icon a2ui-choice-icon--build" aria-hidden>
+              <span className="mention">@components</span>
+              <span className="mention">@patterns</span>
+              <span className="mention">@data</span>
+            </div>
+            <h2>Create a workspace</h2>
+            <p>
+              An app-building workshop: @-mention prepopulated cre8 components,
+              patterns and data sources. Chat on the left, a live app renderer on
+              the right. Save anything up to a full page as a pattern.
+            </p>
+            <span className="a2ui-choice-cta">Open workspace →</span>
+          </Link>
+        </div>
+
+        <footer className="a2ui-landing-footer">
+          <Link href="/" className="a2ui-textlink">← cre8 studio</Link>
+          <span>Powered by cre8-wc + A2UI</span>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/packages/cre8-studio/src/app/a2ui/workspace/page.tsx
+++ b/packages/cre8-studio/src/app/a2ui/workspace/page.tsx
@@ -1,16 +1,9 @@
-import Link from "next/link";
 import Workspace from "@/components/a2ui-demo/workspace";
 
 export default function WorkspacePage() {
   return (
-    <main className="app--fullbleed a2ui-workspace-page">
-      <header className="header" style={{ padding: "10px 16px" }}>
-        <h1 style={{ fontSize: 16 }}>A2UI workspace</h1>
-        <span className="subtitle">@mention patterns · components · data → live app renderer</span>
-        <Link href="/a2ui/brand" className="header-nav-link">Brand →</Link>
-        <Link href="/a2ui" className="header-nav-link">← A2UI</Link>
-      </header>
+    <div className="page page--full">
       <Workspace />
-    </main>
+    </div>
   );
 }

--- a/packages/cre8-studio/src/app/a2ui/workspace/page.tsx
+++ b/packages/cre8-studio/src/app/a2ui/workspace/page.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+import Workspace from "@/components/a2ui-demo/workspace";
+
+export default function WorkspacePage() {
+  return (
+    <main className="app--fullbleed a2ui-workspace-page">
+      <header className="header" style={{ padding: "10px 16px" }}>
+        <h1 style={{ fontSize: 16 }}>A2UI workspace</h1>
+        <span className="subtitle">@mention patterns · components · data → live app renderer</span>
+        <Link href="/a2ui/brand" className="header-nav-link">Brand →</Link>
+        <Link href="/a2ui" className="header-nav-link">← A2UI</Link>
+      </header>
+      <Workspace />
+    </main>
+  );
+}

--- a/packages/cre8-studio/src/app/api/a2ui-patterns/route.ts
+++ b/packages/cre8-studio/src/app/api/a2ui-patterns/route.ts
@@ -1,0 +1,61 @@
+import { readFile, readdir } from "fs/promises";
+import path from "path";
+import type { Pattern } from "@/lib/a2ui-demo/types";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Human metadata for the bundled a2ui example specs. Files live in the cre8-wc
+// package; we read them at request time (like the cdn route) to seed the
+// workspace's builtin pattern library — full UI pages the user can @-mention.
+const META: Record<string, { name: string; description: string; category: string }> = {
+  "portfolio.json": {
+    name: "Portfolio Page",
+    description: "Full single-page portfolio: hero, work grid, about, contact.",
+    category: "Page",
+  },
+  "card-gallery.json": {
+    name: "Card Gallery",
+    description: "Responsive grid of product/content cards with actions.",
+    category: "Layout",
+  },
+  "dating-grid.json": {
+    name: "Profile Grid",
+    description: "Profile cards with like/pass actions in a responsive grid.",
+    category: "Layout",
+  },
+};
+
+const EXAMPLES_DIR = "../cre8-wc/a2ui/examples";
+
+export async function GET() {
+  try {
+    const dir = path.resolve(process.cwd(), EXAMPLES_DIR);
+    const files = (await readdir(dir)).filter((f) => f.endsWith(".json"));
+    const patterns: Pattern[] = [];
+    for (const file of files) {
+      const meta = META[file];
+      if (!meta) continue;
+      try {
+        const raw = await readFile(path.join(dir, file), "utf8");
+        const spec = JSON.parse(raw);
+        patterns.push({
+          id: `builtin:${file.replace(/\.json$/, "")}`,
+          name: meta.name,
+          description: meta.description,
+          category: meta.category,
+          spec,
+          builtin: true,
+        });
+      } catch {
+        // skip unreadable / invalid example
+      }
+    }
+    return Response.json({ patterns });
+  } catch (err) {
+    return Response.json(
+      { patterns: [], error: err instanceof Error ? err.message : String(err) },
+      { status: 200 },
+    );
+  }
+}

--- a/packages/cre8-studio/src/app/api/brand-extract/route.ts
+++ b/packages/cre8-studio/src/app/api/brand-extract/route.ts
@@ -1,0 +1,75 @@
+import { buildRamp } from "@/lib/a2ui-demo/ramp";
+import type { BrandTheme } from "@/lib/a2ui-demo/types";
+import { buildThemeCss, extractFromUrl } from "@/lib/server/brand-theme";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type Body = {
+  url?: string;
+  primary?: string; // hex — manual override / color picker
+  name?: string;
+  fontFamily?: string;
+};
+
+const HEX = /^#[0-9a-fA-F]{6}$/;
+
+export async function POST(req: Request) {
+  let body: Body;
+  try {
+    body = (await req.json()) as Body;
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  try {
+    let primary = body.primary && HEX.test(body.primary) ? body.primary.toUpperCase() : undefined;
+    let fontFamily = body.fontFamily;
+    let source: string | undefined;
+    let candidates: string[] = [];
+
+    if (!primary && body.url) {
+      const extracted = await extractFromUrl(body.url);
+      primary = extracted.primary;
+      fontFamily = fontFamily ?? extracted.fontFamily;
+      candidates = extracted.candidates;
+      source = body.url;
+    }
+
+    if (!primary) {
+      return Response.json(
+        { error: "Provide a website url or a primary color (#RRGGBB)." },
+        { status: 400 },
+      );
+    }
+
+    const ramp = buildRamp(primary);
+    const css = await buildThemeCss(primary);
+
+    const theme: BrandTheme = {
+      name: body.name?.trim() || hostFrom(source) || "Custom brand",
+      primary,
+      fontFamily,
+      source,
+      ramp,
+      css,
+      createdAt: 0, // stamped client-side (no Date in some server contexts)
+    };
+
+    return Response.json({ theme, candidates });
+  } catch (err) {
+    return Response.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 502 },
+    );
+  }
+}
+
+function hostFrom(url?: string): string | undefined {
+  if (!url) return undefined;
+  try {
+    return new URL(/^https?:\/\//.test(url) ? url : `https://${url}`).hostname.replace(/^www\./, "");
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/cre8-studio/src/app/api/chat/route.ts
+++ b/packages/cre8-studio/src/app/api/chat/route.ts
@@ -6,14 +6,13 @@ import {
   type FunctionDeclaration,
   type Part,
 } from "@google/genai";
-import { registerCatalog, validateSpec, type ComponentSpec } from "@tmorrow/cre8-wc/a2ui";
-import { catalog as catalogJson } from "@/lib/catalog-index";
+import { type ComponentSpec } from "@tmorrow/cre8-wc/a2ui";
 import { buildSystemPrompt } from "@/lib/system-prompt";
+import { validateA2uiSpec } from "@/lib/server/cre8-mcp";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const registered = registerCatalog(catalogJson as unknown as Parameters<typeof registerCatalog>[0]);
 const SYSTEM = buildSystemPrompt();
 
 const renderUiDeclaration: FunctionDeclaration = {
@@ -164,12 +163,11 @@ export async function POST(req: Request) {
                 send("tool_use_error", { id, error: "render_ui called without a spec" });
                 continue;
               }
-              try {
-                validateSpec(args.spec, registered);
+              const { result } = await validateA2uiSpec(args.spec);
+              if (result.ok) {
                 send("tool_use", { id, spec: args.spec, caption: args.caption });
-              } catch (err) {
-                const error = err instanceof Error ? err.message : String(err);
-                send("tool_use_error", { id, error, spec: args.spec });
+              } else {
+                send("tool_use_error", { id, error: result.error, spec: args.spec });
               }
             }
           }

--- a/packages/cre8-studio/src/app/build/page.tsx
+++ b/packages/cre8-studio/src/app/build/page.tsx
@@ -1,16 +1,9 @@
-import Link from "next/link";
 import AppBuilder from "@/components/app-builder";
 
 export default function BuildPage() {
   return (
-    <main className="app">
-      <header className="header">
-        <h1>cre8 apps</h1>
-        <span className="subtitle">describe an app → live canvas + Supabase schema</span>
-        <Link href="/" className="header-nav-link">← Studio</Link>
-        <Link href="/stack" className="header-nav-link">Stack →</Link>
-      </header>
+    <div className="page page--center">
       <AppBuilder />
-    </main>
+    </div>
   );
 }

--- a/packages/cre8-studio/src/app/data/page.tsx
+++ b/packages/cre8-studio/src/app/data/page.tsx
@@ -1,16 +1,8 @@
-import Link from "next/link";
 import DataAgent from "@/components/data-agent";
 
 export default function DataAgentPage() {
   return (
-    <div className="app--fullbleed">
-      <header className="header" style={{ padding: "12px 20px" }}>
-        <h1 style={{ fontSize: 16 }}>cre8 data agent</h1>
-        <span className="subtitle">Claude Agent SDK · cre8 a2ui</span>
-        <Link href="/" className="header-nav-link">Studio →</Link>
-        <Link href="/build" className="header-nav-link">App Builder →</Link>
-        <Link href="/stack" className="header-nav-link">Stack →</Link>
-      </header>
+    <div className="page page--full">
       <DataAgent />
     </div>
   );

--- a/packages/cre8-studio/src/app/explore/page.tsx
+++ b/packages/cre8-studio/src/app/explore/page.tsx
@@ -1,15 +1,8 @@
-import Link from "next/link";
 import ExploreCanvasView from "@/components/explore-canvas-view";
 
 export default function ExplorePage() {
   return (
-    <div className="app--fullbleed">
-      <header className="header" style={{ padding: "12px 20px" }}>
-        <h1 style={{ fontSize: 16 }}>cre8 explore</h1>
-        <span className="subtitle">Agent-driven data exploration · mcp-ui</span>
-        <Link href="/" className="header-nav-link">Studio →</Link>
-        <Link href="/data" className="header-nav-link">Data Agent →</Link>
-      </header>
+    <div className="page page--full">
       <ExploreCanvasView dataset="ecommerce" />
     </div>
   );

--- a/packages/cre8-studio/src/app/globals.css
+++ b/packages/cre8-studio/src/app/globals.css
@@ -801,3 +801,577 @@ body > div:first-child {
   padding: 20px;
   background: var(--cre8-color-bg-subtle, #f5f5f5);
 }
+
+/* ===========================================================================
+   cre8 A2UI demo — landing, brand extractor, workspace
+   =========================================================================== */
+
+:root {
+  --a2ui-brand: var(--cre8-color-button-primary-bg, #3b82f6);
+  --a2ui-brand-content: var(--cre8-color-button-primary-content, #fff);
+  --a2ui-border: var(--cre8-color-border-default, #e2e8f0);
+  --a2ui-subtle: var(--cre8-color-bg-subtle, #f6f8fb);
+}
+
+/* ---- Landing ------------------------------------------------------------- */
+.a2ui-landing {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 20px;
+}
+.a2ui-landing-inner {
+  width: 100%;
+  max-width: 980px;
+}
+.a2ui-landing-header {
+  text-align: center;
+  margin-bottom: 40px;
+}
+.a2ui-eyebrow {
+  display: inline-block;
+  font-size: 12px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--a2ui-brand);
+  margin-bottom: 12px;
+}
+.a2ui-landing-header h1 {
+  margin: 0 0 14px;
+  font-size: clamp(28px, 4vw, 44px);
+  line-height: 1.1;
+  font-weight: 700;
+}
+.a2ui-landing-header p {
+  margin: 0 auto;
+  max-width: 620px;
+  font-size: 17px;
+  line-height: 1.6;
+  opacity: 0.7;
+}
+.a2ui-choice-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+@media (max-width: 720px) {
+  .a2ui-choice-grid { grid-template-columns: 1fr; }
+}
+.a2ui-choice-card {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  border: 1px solid var(--a2ui-border);
+  border-radius: 16px;
+  padding: 28px;
+  background: var(--cre8-color-bg-default, #fff);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+.a2ui-choice-card:hover {
+  transform: translateY(-3px);
+  border-color: var(--a2ui-brand);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);
+}
+.a2ui-choice-icon {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+.a2ui-choice-icon .swatch {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+}
+.swatch.s1 { background: var(--cre8-color-button-primary-bg, #3b82f6); }
+.swatch.s2 { background: var(--cre8-color-button-primary-bg-hover, #2563eb); }
+.swatch.s3 { background: var(--cre8-color-button-primary-bg-active, #1d4ed8); }
+.a2ui-choice-icon--build {
+  flex-wrap: wrap;
+}
+.a2ui-choice-icon--build .mention {
+  font-family: ui-monospace, "SF Mono", monospace;
+  font-size: 13px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  background: var(--a2ui-subtle);
+  border: 1px solid var(--a2ui-border);
+  color: var(--a2ui-brand);
+}
+.a2ui-choice-card h2 {
+  margin: 0 0 10px;
+  font-size: 22px;
+}
+.a2ui-choice-card p {
+  margin: 0 0 18px;
+  line-height: 1.55;
+  opacity: 0.72;
+}
+.a2ui-choice-cta {
+  font-weight: 600;
+  color: var(--a2ui-brand);
+}
+.a2ui-landing-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 36px;
+  font-size: 13px;
+  opacity: 0.6;
+}
+.a2ui-textlink {
+  color: inherit;
+  text-decoration: none;
+}
+.a2ui-textlink:hover { text-decoration: underline; }
+
+/* ---- Shared page chrome -------------------------------------------------- */
+.a2ui-page {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  height: 100vh;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 16px;
+  overflow: hidden;
+}
+.a2ui-page > .brand-extractor { overflow-y: auto; padding: 20px 0 48px; }
+
+/* ---- Brand extractor ----------------------------------------------------- */
+.brand-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+.brand-card {
+  border: 1px solid var(--a2ui-border);
+  border-radius: 12px;
+  padding: 16px;
+  background: var(--cre8-color-bg-default, #fff);
+}
+.brand-card--active { border-color: var(--a2ui-brand); }
+.brand-card h3 { margin: 0 0 4px; font-size: 15px; }
+.brand-hint { margin: 0 0 12px; font-size: 13px; opacity: 0.6; }
+.brand-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.brand-row input[type="text"] {
+  flex: 1;
+  min-width: 0;
+  padding: 9px 11px;
+  border: 1px solid var(--a2ui-border);
+  border-radius: 8px;
+  font: inherit;
+  background: var(--cre8-color-bg-default, #fff);
+  color: inherit;
+}
+.brand-color-input {
+  width: 44px;
+  height: 40px;
+  padding: 2px;
+  border: 1px solid var(--a2ui-border);
+  border-radius: 8px;
+  background: none;
+}
+.brand-hex-input { width: 110px; font-family: ui-monospace, monospace; }
+.brand-row button,
+.brand-primary-btn {
+  padding: 9px 16px;
+  border: none;
+  border-radius: 8px;
+  background: var(--a2ui-brand);
+  color: var(--a2ui-brand-content);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.brand-row button:disabled { opacity: 0.5; cursor: not-allowed; }
+.brand-link-btn {
+  background: none;
+  border: none;
+  color: var(--a2ui-brand);
+  cursor: pointer;
+  font: inherit;
+  margin-left: auto;
+  text-decoration: underline;
+}
+.brand-active-row { display: flex; align-items: center; gap: 10px; font-size: 14px; }
+.brand-dot { width: 18px; height: 18px; border-radius: 50%; border: 1px solid var(--a2ui-border); }
+
+.brand-result {
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  gap: 20px;
+  margin-top: 22px;
+}
+@media (max-width: 820px) { .brand-result { grid-template-columns: 1fr; } }
+.brand-meta-head { display: flex; align-items: baseline; gap: 10px; margin-bottom: 14px; }
+.brand-meta-head h2 { margin: 0; font-size: 20px; }
+.brand-source { font-size: 12px; opacity: 0.55; }
+.brand-ramp {
+  display: flex;
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid var(--a2ui-border);
+  margin-bottom: 14px;
+}
+.ramp-step {
+  flex: 1;
+  height: 52px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+}
+.brand-facts { display: flex; flex-direction: column; gap: 4px; font-size: 14px; margin-bottom: 16px; }
+.brand-facts strong { display: inline-block; width: 70px; opacity: 0.55; font-weight: 600; }
+.brand-candidates { margin-bottom: 18px; }
+.brand-swatches { display: flex; gap: 6px; margin-top: 6px; }
+.brand-swatch {
+  width: 30px; height: 30px; border-radius: 7px;
+  border: 1px solid var(--a2ui-border); cursor: pointer;
+}
+.brand-actions { display: flex; gap: 10px; }
+.brand-go-btn { background: var(--cre8-color-button-primary-bg-active, #1d4ed8); }
+.brand-preview {
+  border: 1px solid var(--a2ui-border);
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--cre8-color-bg-default, #fff);
+}
+.brand-preview-label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.5;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--a2ui-border);
+}
+.brand-preview-frame { padding: 4px; max-height: 560px; overflow: auto; }
+
+/* ---- Workspace ----------------------------------------------------------- */
+.workspace-grid {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 280px minmax(360px, 1fr) minmax(380px, 1.1fr);
+  overflow: hidden;
+  border-top: 1px solid var(--a2ui-border);
+}
+@media (max-width: 1080px) {
+  .workspace-grid { grid-template-columns: 240px 1fr; }
+  .app-renderer { display: none; }
+}
+
+/* library */
+.library-panel {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--a2ui-border);
+  background: var(--a2ui-subtle);
+  overflow: hidden;
+}
+.library-tabs { display: flex; padding: 8px 8px 0; gap: 4px; }
+.library-tabs button {
+  flex: 1;
+  padding: 8px 4px;
+  border: none;
+  background: none;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  border-radius: 7px 7px 0 0;
+  color: inherit;
+  opacity: 0.6;
+}
+.library-tabs button span {
+  display: inline-block;
+  font-size: 10px;
+  background: var(--a2ui-border);
+  border-radius: 8px;
+  padding: 0 5px;
+  margin-left: 2px;
+}
+.library-tabs button.active { opacity: 1; background: var(--cre8-color-bg-default, #fff); }
+.library-search {
+  margin: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--a2ui-border);
+  border-radius: 8px;
+  font: inherit;
+  font-size: 13px;
+  background: var(--cre8-color-bg-default, #fff);
+  color: inherit;
+}
+.library-list { flex: 1; overflow-y: auto; padding: 0 8px 12px; display: flex; flex-direction: column; gap: 6px; }
+.library-item {
+  display: flex;
+  align-items: stretch;
+  border: 1px solid var(--a2ui-border);
+  border-radius: 9px;
+  background: var(--cre8-color-bg-default, #fff);
+  overflow: hidden;
+  text-align: left;
+}
+.library-item--compact { cursor: pointer; padding: 8px 10px; flex-direction: column; gap: 2px; }
+.library-item--compact:hover { border-color: var(--a2ui-brand); }
+.library-item-main {
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+  border: none;
+  background: none;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.library-item-main:hover { background: var(--a2ui-subtle); }
+.library-item-title {
+  font-size: 13px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: ui-monospace, "SF Mono", monospace;
+}
+.library-item--compact .library-item-title { font-size: 12.5px; }
+.library-item-detail {
+  font-size: 11.5px;
+  opacity: 0.6;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.library-badge {
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  padding: 1px 5px;
+  border-radius: 6px;
+  background: var(--a2ui-border);
+  opacity: 0.8;
+  font-family: system-ui, sans-serif;
+}
+.library-badge--user { background: var(--a2ui-brand); color: var(--a2ui-brand-content); opacity: 1; }
+.library-item-actions { display: flex; flex-direction: column; border-left: 1px solid var(--a2ui-border); }
+.library-item-actions button {
+  flex: 1;
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 0 8px;
+  font-size: 12px;
+  color: inherit;
+  opacity: 0.6;
+}
+.library-item-actions button:hover { opacity: 1; background: var(--a2ui-subtle); }
+
+/* chat column */
+.workspace-chat {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--a2ui-border);
+  overflow: hidden;
+}
+.workspace-chat .thread { flex: 1; padding: 16px; }
+.workspace-empty { padding: 24px 8px; }
+.workspace-empty-lead { font-size: 15px; line-height: 1.6; opacity: 0.75; margin: 0 0 16px; }
+.workspace-starters { display: flex; flex-direction: column; gap: 8px; }
+.workspace-starter {
+  text-align: left;
+  border: 1px solid var(--a2ui-border);
+  border-radius: 9px;
+  background: var(--cre8-color-bg-default, #fff);
+  padding: 11px 13px;
+  font: inherit;
+  font-size: 13.5px;
+  cursor: pointer;
+  color: inherit;
+}
+.workspace-starter:hover { border-color: var(--a2ui-brand); }
+.workspace-streaming { font-size: 12px; opacity: 0.6; padding: 4px 2px; font-style: italic; }
+.bubble-rendered {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--a2ui-subtle);
+  border: 1px dashed var(--a2ui-border);
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 13px;
+}
+.bubble-rendered-tag {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--a2ui-brand);
+  white-space: nowrap;
+}
+.mention-token {
+  font-family: ui-monospace, "SF Mono", monospace;
+  font-size: 0.92em;
+  background: rgba(59, 130, 246, 0.12);
+  color: var(--a2ui-brand);
+  border-radius: 5px;
+  padding: 0 3px;
+}
+.workspace-composer { border-top: 1px solid var(--a2ui-border); padding: 12px; position: relative; }
+
+/* mention input */
+.mention-input { position: relative; }
+.mention-input textarea {
+  width: 100%;
+  resize: none;
+  padding: 11px 12px;
+  border: 1px solid var(--a2ui-border);
+  border-radius: 10px;
+  font: inherit;
+  font-size: 14px;
+  background: var(--cre8-color-bg-default, #fff);
+  color: inherit;
+}
+.mention-input textarea:focus { outline: none; border-color: var(--a2ui-brand); }
+.mention-input-foot { display: flex; align-items: center; justify-content: space-between; margin-top: 8px; }
+.mention-tip { font-size: 11px; opacity: 0.55; }
+.mention-tip kbd {
+  font-family: ui-monospace, monospace;
+  background: var(--a2ui-subtle);
+  border: 1px solid var(--a2ui-border);
+  border-radius: 4px;
+  padding: 0 4px;
+}
+.mention-input-foot button {
+  padding: 8px 18px;
+  border: none;
+  border-radius: 8px;
+  background: var(--a2ui-brand);
+  color: var(--a2ui-brand-content);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+.mention-input-foot button:disabled { opacity: 0.5; cursor: not-allowed; }
+.mention-menu {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  max-height: 320px;
+  overflow-y: auto;
+  background: var(--cre8-color-bg-default, #fff);
+  border: 1px solid var(--a2ui-border);
+  border-radius: 12px;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.16);
+  z-index: 20;
+  padding: 6px;
+}
+.mention-group-head {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  font-weight: 700;
+  opacity: 0.45;
+  padding: 8px 8px 4px;
+}
+.mention-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  text-align: left;
+  border: none;
+  background: none;
+  border-radius: 8px;
+  padding: 7px 8px;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+.mention-option.active { background: var(--a2ui-subtle); }
+.mention-kind {
+  width: 22px;
+  height: 22px;
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  font-size: 12px;
+  background: var(--a2ui-border);
+}
+.mention-kind--pattern { background: rgba(59, 130, 246, 0.18); color: var(--a2ui-brand); }
+.mention-kind--component { background: rgba(16, 185, 129, 0.18); color: #0f766e; }
+.mention-kind--data { background: rgba(217, 119, 6, 0.18); color: #b45309; }
+.mention-option-text { min-width: 0; display: flex; flex-direction: column; }
+.mention-option-title { font-size: 13px; font-weight: 600; font-family: ui-monospace, monospace; }
+.mention-option-detail { font-size: 11.5px; opacity: 0.6; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* app renderer */
+.app-renderer { display: flex; flex-direction: column; overflow: hidden; background: var(--a2ui-subtle); }
+.app-renderer-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--a2ui-border);
+  background: var(--cre8-color-bg-default, #fff);
+}
+.app-renderer-title { font-size: 13px; font-weight: 600; }
+.app-renderer-tabs { display: flex; gap: 2px; margin-left: 8px; }
+.app-renderer-tabs button {
+  border: none;
+  background: none;
+  font: inherit;
+  font-size: 12px;
+  padding: 5px 9px;
+  border-radius: 6px;
+  cursor: pointer;
+  color: inherit;
+  opacity: 0.6;
+}
+.app-renderer-tabs button.active { background: var(--a2ui-subtle); opacity: 1; }
+.app-renderer-tabs button:disabled { opacity: 0.3; cursor: not-allowed; }
+.app-renderer-save {
+  margin-left: auto;
+  border: 1px solid var(--a2ui-brand);
+  background: none;
+  color: var(--a2ui-brand);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 11px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+.app-renderer-save:disabled { opacity: 0.4; cursor: not-allowed; border-color: var(--a2ui-border); color: inherit; }
+.app-renderer-body { flex: 1; overflow: auto; }
+.app-renderer-canvas { padding: 16px; }
+.app-renderer-empty {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 40px;
+  gap: 14px;
+}
+.app-renderer-empty-glyph { font-size: 44px; opacity: 0.25; }
+.app-renderer-empty p { margin: 0; max-width: 320px; line-height: 1.6; opacity: 0.6; font-size: 14px; }
+.app-renderer-spec {
+  margin: 0;
+  padding: 16px;
+  font-family: ui-monospace, "SF Mono", monospace;
+  font-size: 11.5px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/packages/cre8-studio/src/app/globals.css
+++ b/packages/cre8-studio/src/app/globals.css
@@ -1,5 +1,123 @@
 @import "@tmorrow/cre8-wc/design-tokens/brands/cre8-a2ui/css/tokens_cre8-a2ui.css";
 
+/* ===========================================================================
+   cre8 studio — design system (dark-first, refined-product)
+   Chrome uses the --ui-* scale below. The cre8-a2ui --cre8-* tokens are left
+   untouched at :root so agent-rendered components keep their (light) theme and
+   sit on an always-light "artboard". Light app theme via [data-theme="light"].
+   =========================================================================== */
+:root,
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  /* surfaces — from deepest to most elevated */
+  --ui-bg: #0b0d10;
+  --ui-surface: #14171c;
+  --ui-surface-2: #1b1f26;
+  --ui-surface-3: #232830;
+  --ui-overlay: rgba(8, 10, 13, 0.72);
+
+  /* text */
+  --ui-fg: #eef1f5;
+  --ui-fg-muted: #99a2b0;
+  --ui-fg-subtle: #6b7280;
+
+  /* borders / hairlines */
+  --ui-border: rgba(255, 255, 255, 0.10);
+  --ui-border-subtle: rgba(255, 255, 255, 0.06);
+  --ui-border-strong: rgba(255, 255, 255, 0.18);
+
+  /* accent — used sparingly */
+  --ui-accent: #6d8bff;
+  --ui-accent-hover: #5f7ff5;
+  --ui-accent-active: #4f6ee8;
+  --ui-accent-fg: #0b0d10;
+  --ui-accent-soft: rgba(109, 139, 255, 0.14);
+  --ui-accent-ring: rgba(109, 139, 255, 0.45);
+
+  /* feedback */
+  --ui-danger: #ff6b6b;
+  --ui-danger-bg: rgba(255, 107, 107, 0.12);
+  --ui-success: #43c59e;
+  --ui-warning: #e3b341;
+
+  /* category accents (mention kinds, badges) */
+  --ui-cat-pattern: #6d8bff;
+  --ui-cat-component: #43c59e;
+  --ui-cat-data: #e0a458;
+
+  /* always-light artboard for rendered cre8 components */
+  --ui-artboard: #ffffff;
+  --ui-artboard-2: #f5f7fa;
+  --ui-artboard-ink: #1a1d23;
+  --ui-artboard-border: #e6e9ef;
+
+  /* radii */
+  --ui-r-sm: 7px;
+  --ui-r-md: 10px;
+  --ui-r-lg: 14px;
+  --ui-r-xl: 20px;
+
+  /* spacing scale */
+  --ui-s1: 4px;
+  --ui-s2: 8px;
+  --ui-s3: 12px;
+  --ui-s4: 16px;
+  --ui-s5: 24px;
+  --ui-s6: 32px;
+
+  /* elevation */
+  --ui-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --ui-shadow-md: 0 6px 20px rgba(0, 0, 0, 0.35);
+  --ui-shadow-lg: 0 24px 60px rgba(0, 0, 0, 0.5);
+
+  /* motion */
+  --ui-ease: cubic-bezier(0.4, 0, 0.2, 1);
+  --ui-fast: 120ms;
+  --ui-med: 200ms;
+
+  /* layout */
+  --ui-rail-w: 60px;
+  --ui-topbar-h: 52px;
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+  --ui-bg: #f6f7f9;
+  --ui-surface: #ffffff;
+  --ui-surface-2: #f1f3f6;
+  --ui-surface-3: #e8ebf0;
+  --ui-overlay: rgba(15, 23, 42, 0.32);
+
+  --ui-fg: #1a1d23;
+  --ui-fg-muted: #5a6573;
+  --ui-fg-subtle: #8b94a3;
+
+  --ui-border: rgba(15, 23, 42, 0.12);
+  --ui-border-subtle: rgba(15, 23, 42, 0.07);
+  --ui-border-strong: rgba(15, 23, 42, 0.22);
+
+  --ui-accent: #4f6ee8;
+  --ui-accent-hover: #4361d8;
+  --ui-accent-active: #3a55c4;
+  --ui-accent-fg: #ffffff;
+  --ui-accent-soft: rgba(79, 110, 232, 0.10);
+  --ui-accent-ring: rgba(79, 110, 232, 0.40);
+
+  --ui-danger: #d64545;
+  --ui-danger-bg: rgba(214, 69, 69, 0.08);
+  --ui-success: #1f9d76;
+  --ui-warning: #b8860b;
+
+  --ui-cat-pattern: #4f6ee8;
+  --ui-cat-component: #1f9d76;
+  --ui-cat-data: #b06f2b;
+
+  --ui-shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.08);
+  --ui-shadow-md: 0 6px 20px rgba(15, 23, 42, 0.10);
+  --ui-shadow-lg: 0 24px 60px rgba(15, 23, 42, 0.16);
+}
+
 *,
 *::before,
 *::after {
@@ -11,17 +129,59 @@ body {
   margin: 0;
   padding: 0;
   height: 100%;
-  background: var(--cre8-color-bg-default);
-  color: var(--cre8-color-content-default);
+  background: var(--ui-bg);
+  color: var(--ui-fg);
   font-family: var(--cre8-typography-body-default-font-family, system-ui, sans-serif);
-  font-size: var(--cre8-typography-body-default-font-size, 16px);
-  line-height: var(--cre8-typography-body-default-line-height, 1.5);
+  font-size: 15px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+::selection {
+  background: var(--ui-accent-soft);
+}
+
+/* refined scrollbars */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--ui-border-strong) transparent;
+}
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+*::-webkit-scrollbar-thumb {
+  background: var(--ui-border-strong);
+  border-radius: 99px;
+  border: 3px solid transparent;
+  background-clip: content-box;
+}
+*::-webkit-scrollbar-thumb:hover {
+  background: var(--ui-fg-subtle);
+  background-clip: content-box;
+}
+
+:focus-visible {
+  outline: 2px solid var(--ui-accent-ring);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.001ms !important;
+    animation-duration: 0.001ms !important;
+  }
 }
 
 #__next,
 body > div:first-child {
   height: 100%;
 }
+
 
 .app {
   display: grid;
@@ -34,7 +194,7 @@ body > div:first-child {
 
 .header {
   padding: 16px 0;
-  border-bottom: 1px solid var(--cre8-color-border-default);
+  border-bottom: 1px solid var(--ui-border);
   display: flex;
   align-items: baseline;
   gap: 12px;
@@ -48,14 +208,14 @@ body > div:first-child {
 
 .header .subtitle {
   font-size: 13px;
-  color: var(--cre8-color-content-default);
+  color: var(--ui-fg);
   opacity: 0.6;
 }
 
 .header-nav-link {
   margin-left: auto;
   font-size: 13px;
-  color: var(--cre8-color-content-default);
+  color: var(--ui-fg);
   opacity: 0.7;
   text-decoration: none;
 }
@@ -82,13 +242,13 @@ body > div:first-child {
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  color: var(--cre8-color-content-default);
+  color: var(--ui-fg);
   opacity: 0.55;
 }
 
 .msg-user .bubble {
-  background: var(--cre8-color-bg-subtle);
-  border: 1px solid var(--cre8-color-border-default);
+  background: var(--ui-surface-2);
+  border: 1px solid var(--ui-border);
   padding: 12px 14px;
   border-radius: 10px;
   align-self: flex-end;
@@ -101,8 +261,8 @@ body > div:first-child {
   max-width: 80%;
   border-radius: 10px;
   padding: 10px 12px;
-  background: var(--cre8-color-bg-moderate, var(--cre8-color-bg-subtle));
-  border: 1px solid var(--cre8-color-border-default);
+  background: var(--ui-surface-3, var(--ui-surface-2));
+  border: 1px solid var(--ui-border);
 }
 
 .bubble-action .action-label {
@@ -142,22 +302,22 @@ body > div:first-child {
   opacity: 0.65;
   font-size: 13px;
   padding-left: 12px;
-  border-left: 2px solid var(--cre8-color-border-default);
+  border-left: 2px solid var(--ui-border);
 }
 
 .a2ui-canvas {
-  border: 1px solid var(--cre8-color-border-default);
+  border: 1px solid var(--ui-border);
   border-radius: 12px;
   padding: 16px;
-  background: var(--cre8-color-bg-default);
+  background: var(--ui-surface);
 }
 
 .a2ui-canvas-error {
-  border: 1px solid var(--cre8-color-border-error, #dc3545);
+  border: 1px solid var(--ui-danger, #dc3545);
   border-radius: 10px;
   padding: 12px;
-  color: var(--cre8-color-content-error, #dc3545);
-  background: var(--cre8-color-bg-error, #fff5f5);
+  color: var(--ui-danger, #dc3545);
+  background: var(--ui-danger-bg, #fff5f5);
   font-family: ui-monospace, monospace;
   font-size: 12px;
   white-space: pre-wrap;
@@ -167,7 +327,7 @@ body > div:first-child {
   display: flex;
   gap: 8px;
   padding: 12px 0 20px;
-  border-top: 1px solid var(--cre8-color-border-default);
+  border-top: 1px solid var(--ui-border);
 }
 
 .composer textarea {
@@ -176,15 +336,15 @@ body > div:first-child {
   min-height: 44px;
   max-height: 200px;
   padding: 10px 12px;
-  border: 1px solid var(--cre8-color-border-default);
+  border: 1px solid var(--ui-border);
   border-radius: 8px;
   font: inherit;
-  background: var(--cre8-color-bg-default);
-  color: var(--cre8-color-content-default);
+  background: var(--ui-surface);
+  color: var(--ui-fg);
 }
 
 .composer textarea:focus {
-  outline: 2px solid var(--cre8-color-border-brand, var(--cre8-color-border-strong));
+  outline: 2px solid var(--ui-accent, var(--ui-border-strong));
   outline-offset: -1px;
   border-color: transparent;
 }
@@ -193,8 +353,8 @@ body > div:first-child {
   padding: 0 18px;
   border: none;
   border-radius: 8px;
-  background: var(--cre8-color-button-primary-bg, var(--cre8-color-bg-brand));
-  color: var(--cre8-color-button-primary-content, #fff);
+  background: var(--ui-accent, var(--ui-accent));
+  color: var(--ui-accent-fg, #fff);
   font: inherit;
   font-weight: 600;
   cursor: pointer;
@@ -217,10 +377,10 @@ body > div:first-child {
 
 .btn-stop {
   padding: 0 18px;
-  border: 1px solid var(--cre8-color-border-default);
+  border: 1px solid var(--ui-border);
   border-radius: 8px;
   background: transparent;
-  color: var(--cre8-color-content-default);
+  color: var(--ui-fg);
   font: inherit;
   font-weight: 600;
   cursor: pointer;
@@ -236,7 +396,7 @@ body > div:first-child {
   display: flex;
   gap: 24px;
   padding: 12px 0;
-  border-bottom: 1px solid var(--cre8-color-border-default);
+  border-bottom: 1px solid var(--ui-border);
 }
 
 .pipeline-step {
@@ -266,15 +426,15 @@ body > div:first-child {
   display: flex;
   flex-direction: column;
   gap: 0;
-  border: 1px solid var(--cre8-color-border-default);
+  border: 1px solid var(--ui-border);
   border-radius: 12px;
   overflow: hidden;
 }
 
 .tab-bar {
   display: flex;
-  border-bottom: 1px solid var(--cre8-color-border-default);
-  background: var(--cre8-color-bg-subtle);
+  border-bottom: 1px solid var(--ui-border);
+  background: var(--ui-surface-2);
 }
 
 .tab {
@@ -284,9 +444,9 @@ body > div:first-child {
   font: inherit;
   font-size: 13px;
   cursor: pointer;
-  color: var(--cre8-color-content-default);
+  color: var(--ui-fg);
   opacity: 0.65;
-  border-right: 1px solid var(--cre8-color-border-default);
+  border-right: 1px solid var(--ui-border);
 }
 
 .tab:last-child {
@@ -296,7 +456,7 @@ body > div:first-child {
 .tab.active {
   opacity: 1;
   font-weight: 600;
-  background: var(--cre8-color-bg-default);
+  background: var(--ui-surface);
 }
 
 .tab:disabled {
@@ -309,7 +469,7 @@ body > div:first-child {
   width: 100%;
   min-height: 400px;
   border: none;
-  background: var(--cre8-color-bg-default, #fff);
+  background: var(--ui-surface, #fff);
 }
 
 .builder-code {
@@ -321,7 +481,7 @@ body > div:first-child {
   white-space: pre;
   overflow: auto;
   max-height: 480px;
-  background: var(--cre8-color-bg-subtle);
+  background: var(--ui-surface-2);
 }
 
 .builder-waiting {
@@ -332,7 +492,7 @@ body > div:first-child {
 }
 
 .agent-logs {
-  border: 1px solid var(--cre8-color-border-default);
+  border: 1px solid var(--ui-border);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -342,7 +502,7 @@ body > div:first-child {
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
-  background: var(--cre8-color-bg-subtle);
+  background: var(--ui-surface-2);
   text-transform: uppercase;
   letter-spacing: 0.4px;
   opacity: 0.7;
@@ -350,7 +510,7 @@ body > div:first-child {
 
 .agent-log-entry {
   padding: 8px 12px;
-  border-top: 1px solid var(--cre8-color-border-default);
+  border-top: 1px solid var(--ui-border);
 }
 
 .agent-log-name {
@@ -386,13 +546,13 @@ body > div:first-child {
   grid-template-columns: 40% 60%;
   flex: 1;
   overflow: hidden;
-  border-top: 1px solid var(--cre8-color-border-default, #eee);
+  border-top: 1px solid var(--ui-border, #eee);
 }
 
 .stack-chat {
   display: flex;
   flex-direction: column;
-  border-right: 1px solid var(--cre8-color-border-default, #eee);
+  border-right: 1px solid var(--ui-border, #eee);
   overflow: hidden;
 }
 
@@ -423,7 +583,7 @@ body > div:first-child {
 
 .stack-message--error {
   align-self: flex-start;
-  color: var(--cre8-color-status-error-default, #d32f2f);
+  color: var(--ui-danger, #d32f2f);
 }
 
 .stack-message-role {
@@ -438,14 +598,14 @@ body > div:first-child {
   margin: 0;
   font-size: 14px;
   line-height: 1.5;
-  background: var(--cre8-color-bg-subtle, #f5f5f5);
+  background: var(--ui-surface-2, #f5f5f5);
   padding: 8px 12px;
   border-radius: 8px;
   white-space: pre-wrap;
 }
 
 .stack-message--user .stack-message-text {
-  background: var(--cre8-color-action-primary-default, #1976d2);
+  background: var(--ui-accent, #1976d2);
   color: #fff;
 }
 
@@ -453,7 +613,7 @@ body > div:first-child {
   padding: 6px 16px;
   font-size: 12px;
   opacity: 0.6;
-  border-top: 1px solid var(--cre8-color-border-default, #eee);
+  border-top: 1px solid var(--ui-border, #eee);
   display: flex;
   align-items: center;
   gap: 6px;
@@ -477,16 +637,16 @@ body > div:first-child {
   display: flex;
   gap: 8px;
   padding: 12px;
-  border-top: 1px solid var(--cre8-color-border-default, #eee);
+  border-top: 1px solid var(--ui-border, #eee);
 }
 
 .stack-composer textarea {
   flex: 1;
   padding: 8px 10px;
-  border: 1px solid var(--cre8-color-border-default, #eee);
+  border: 1px solid var(--ui-border, #eee);
   border-radius: 6px;
-  background: var(--cre8-color-bg-default, #fff);
-  color: var(--cre8-color-content-default, #000);
+  background: var(--ui-surface, #fff);
+  color: var(--ui-fg, #000);
   font: inherit;
   font-size: 13px;
   resize: none;
@@ -494,7 +654,7 @@ body > div:first-child {
 
 .stack-composer button {
   padding: 8px 16px;
-  background: var(--cre8-color-action-primary-default, #1976d2);
+  background: var(--ui-accent, #1976d2);
   color: #fff;
   border: none;
   border-radius: 6px;
@@ -514,7 +674,7 @@ body > div:first-child {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--cre8-color-bg-subtle, #f5f5f5);
+  background: var(--ui-surface-2, #f5f5f5);
 }
 
 .stack-iframe {
@@ -534,7 +694,7 @@ body > div:first-child {
 .da-canvas-panel {
   overflow-y: auto;
   padding: 20px;
-  background: var(--cre8-color-bg-subtle);
+  background: var(--ui-surface-2);
   display: flex;
   flex-direction: column;
 }
@@ -575,28 +735,28 @@ body > div:first-child {
   font-size: 12px;
   padding: 3px 10px;
   border-radius: 12px;
-  border: 1px solid var(--cre8-color-border-subtle);
+  border: 1px solid var(--ui-border-subtle);
   background: transparent;
-  color: var(--cre8-color-text-secondary);
+  color: var(--ui-fg-muted);
   cursor: pointer;
 }
 
 .da-data-toggle--active,
 .da-data-toggle:hover {
-  background: var(--cre8-color-bg-subtle);
+  background: var(--ui-surface-2);
 }
 
 .da-data-toggle--loaded {
-  border-color: var(--cre8-color-action-primary);
-  color: var(--cre8-color-action-primary);
+  border-color: var(--ui-accent);
+  color: var(--ui-accent);
 }
 
 .da-data-panel {
-  border: 1px solid var(--cre8-color-border-subtle);
+  border: 1px solid var(--ui-border-subtle);
   border-radius: 8px;
   padding: 10px;
   margin-bottom: 8px;
-  background: var(--cre8-color-bg-subtle);
+  background: var(--ui-surface-2);
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -616,7 +776,7 @@ body > div:first-child {
   font-size: 11px;
   padding: 2px 8px;
   border-radius: 6px;
-  border: 1px solid var(--cre8-color-border-subtle);
+  border: 1px solid var(--ui-border-subtle);
   background: transparent;
   cursor: pointer;
   opacity: 0.7;
@@ -627,17 +787,17 @@ body > div:first-child {
   font-family: var(--font-mono, monospace);
   font-size: 11px;
   resize: vertical;
-  border: 1px solid var(--cre8-color-border-subtle);
+  border: 1px solid var(--ui-border-subtle);
   border-radius: 6px;
   padding: 6px 8px;
-  background: var(--cre8-color-bg);
+  background: var(--ui-bg);
   box-sizing: border-box;
 }
 
 .da-data-error {
   margin: 0;
   font-size: 11px;
-  color: var(--cre8-color-feedback-error);
+  color: var(--ui-danger);
 }
 
 .da-data-badge {
@@ -645,7 +805,7 @@ body > div:first-child {
   font-size: 11px;
   padding: 1px 6px;
   border-radius: 8px;
-  background: var(--cre8-color-action-primary);
+  background: var(--ui-accent);
   color: #fff;
   display: inline-block;
 }
@@ -657,7 +817,7 @@ body > div:first-child {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border-top: 1px solid var(--cre8-color-border-default, #eee);
+  border-top: 1px solid var(--ui-border, #eee);
 }
 
 .explore-grid {
@@ -668,15 +828,15 @@ body > div:first-child {
   grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
   gap: 16px;
   align-content: start;
-  background: var(--cre8-color-bg-subtle, #f5f5f5);
+  background: var(--ui-surface-2, #f5f5f5);
 }
 
 .explore-panel {
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--cre8-color-border-default, #eee);
+  border: 1px solid var(--ui-border, #eee);
   border-radius: 8px;
-  background: var(--cre8-color-bg-default, #fff);
+  background: var(--ui-surface, #fff);
   overflow: hidden;
 }
 
@@ -685,7 +845,7 @@ body > div:first-child {
   align-items: center;
   gap: 8px;
   padding: 8px 12px;
-  border-bottom: 1px solid var(--cre8-color-border-default, #eee);
+  border-bottom: 1px solid var(--ui-border, #eee);
 }
 
 .explore-panel-title {
@@ -710,15 +870,15 @@ body > div:first-child {
   line-height: 1;
   padding: 2px 6px;
   border-radius: 4px;
-  color: var(--cre8-color-content-default, #444);
+  color: var(--ui-fg, #444);
 }
 
 .explore-icon-btn:hover {
-  background: var(--cre8-color-bg-subtle, #f0f0f0);
+  background: var(--ui-surface-2, #f0f0f0);
 }
 
 .explore-icon-btn--active {
-  color: var(--cre8-color-action-primary-default, #1976d2);
+  color: var(--ui-accent, #1976d2);
 }
 
 .explore-panel-body {
@@ -739,7 +899,7 @@ body > div:first-child {
   padding: 24px 0;
   text-align: center;
   font-size: 13px;
-  color: var(--cre8-color-status-error-default, #d32f2f);
+  color: var(--ui-danger, #d32f2f);
 }
 
 .explore-tray {
@@ -747,8 +907,8 @@ body > div:first-child {
   align-items: center;
   gap: 12px;
   padding: 12px 20px;
-  border-top: 1px solid var(--cre8-color-border-default, #eee);
-  background: var(--cre8-color-bg-default, #fff);
+  border-top: 1px solid var(--ui-border, #eee);
+  background: var(--ui-surface, #fff);
 }
 
 .explore-tray-count {
@@ -759,17 +919,17 @@ body > div:first-child {
 
 .explore-btn {
   padding: 8px 16px;
-  border: 1px solid var(--cre8-color-border-default, #ddd);
+  border: 1px solid var(--ui-border, #ddd);
   border-radius: 6px;
-  background: var(--cre8-color-bg-default, #fff);
-  color: var(--cre8-color-content-default, #000);
+  background: var(--ui-surface, #fff);
+  color: var(--ui-fg, #000);
   font: inherit;
   font-size: 13px;
   cursor: pointer;
 }
 
 .explore-btn--primary {
-  background: var(--cre8-color-action-primary-default, #1976d2);
+  background: var(--ui-accent, #1976d2);
   color: #fff;
   border-color: transparent;
 }
@@ -784,22 +944,22 @@ body > div:first-child {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border-top: 1px solid var(--cre8-color-border-default, #eee);
+  border-top: 1px solid var(--ui-border, #eee);
 }
 
 .explore-report-bar {
   display: flex;
   gap: 8px;
   padding: 12px 20px;
-  border-bottom: 1px solid var(--cre8-color-border-default, #eee);
-  background: var(--cre8-color-bg-default, #fff);
+  border-bottom: 1px solid var(--ui-border, #eee);
+  background: var(--ui-surface, #fff);
 }
 
 .explore-report-body {
   flex: 1;
   overflow-y: auto;
   padding: 20px;
-  background: var(--cre8-color-bg-subtle, #f5f5f5);
+  background: var(--ui-surface-2, #f5f5f5);
 }
 
 /* ===========================================================================
@@ -807,10 +967,10 @@ body > div:first-child {
    =========================================================================== */
 
 :root {
-  --a2ui-brand: var(--cre8-color-button-primary-bg, #3b82f6);
-  --a2ui-brand-content: var(--cre8-color-button-primary-content, #fff);
-  --a2ui-border: var(--cre8-color-border-default, #e2e8f0);
-  --a2ui-subtle: var(--cre8-color-bg-subtle, #f6f8fb);
+  --a2ui-brand: var(--ui-accent, #3b82f6);
+  --a2ui-brand-content: var(--ui-accent-fg, #fff);
+  --a2ui-border: var(--ui-border, #e2e8f0);
+  --a2ui-subtle: var(--ui-surface-2, #f6f8fb);
 }
 
 /* ---- Landing ------------------------------------------------------------- */
@@ -866,7 +1026,7 @@ body > div:first-child {
   border: 1px solid var(--a2ui-border);
   border-radius: 16px;
   padding: 28px;
-  background: var(--cre8-color-bg-default, #fff);
+  background: var(--ui-surface, #fff);
   transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
 }
 .a2ui-choice-card:hover {
@@ -884,9 +1044,9 @@ body > div:first-child {
   height: 40px;
   border-radius: 10px;
 }
-.swatch.s1 { background: var(--cre8-color-button-primary-bg, #3b82f6); }
-.swatch.s2 { background: var(--cre8-color-button-primary-bg-hover, #2563eb); }
-.swatch.s3 { background: var(--cre8-color-button-primary-bg-active, #1d4ed8); }
+.swatch.s1 { background: var(--ui-accent, #3b82f6); }
+.swatch.s2 { background: var(--ui-accent-hover, #2563eb); }
+.swatch.s3 { background: var(--ui-accent-active, #1d4ed8); }
 .a2ui-choice-icon--build {
   flex-wrap: wrap;
 }
@@ -948,7 +1108,7 @@ body > div:first-child {
   border: 1px solid var(--a2ui-border);
   border-radius: 12px;
   padding: 16px;
-  background: var(--cre8-color-bg-default, #fff);
+  background: var(--ui-surface, #fff);
 }
 .brand-card--active { border-color: var(--a2ui-brand); }
 .brand-card h3 { margin: 0 0 4px; font-size: 15px; }
@@ -965,7 +1125,7 @@ body > div:first-child {
   border: 1px solid var(--a2ui-border);
   border-radius: 8px;
   font: inherit;
-  background: var(--cre8-color-bg-default, #fff);
+  background: var(--ui-surface, #fff);
   color: inherit;
 }
 .brand-color-input {
@@ -1036,12 +1196,12 @@ body > div:first-child {
   border: 1px solid var(--a2ui-border); cursor: pointer;
 }
 .brand-actions { display: flex; gap: 10px; }
-.brand-go-btn { background: var(--cre8-color-button-primary-bg-active, #1d4ed8); }
+.brand-go-btn { background: var(--ui-accent-active, #1d4ed8); }
 .brand-preview {
   border: 1px solid var(--a2ui-border);
   border-radius: 12px;
   overflow: hidden;
-  background: var(--cre8-color-bg-default, #fff);
+  background: var(--ui-surface, #fff);
 }
 .brand-preview-label {
   font-size: 12px;
@@ -1096,7 +1256,7 @@ body > div:first-child {
   padding: 0 5px;
   margin-left: 2px;
 }
-.library-tabs button.active { opacity: 1; background: var(--cre8-color-bg-default, #fff); }
+.library-tabs button.active { opacity: 1; background: var(--ui-surface, #fff); }
 .library-search {
   margin: 8px;
   padding: 8px 10px;
@@ -1104,7 +1264,7 @@ body > div:first-child {
   border-radius: 8px;
   font: inherit;
   font-size: 13px;
-  background: var(--cre8-color-bg-default, #fff);
+  background: var(--ui-surface, #fff);
   color: inherit;
 }
 .library-list { flex: 1; overflow-y: auto; padding: 0 8px 12px; display: flex; flex-direction: column; gap: 6px; }
@@ -1113,7 +1273,7 @@ body > div:first-child {
   align-items: stretch;
   border: 1px solid var(--a2ui-border);
   border-radius: 9px;
-  background: var(--cre8-color-bg-default, #fff);
+  background: var(--ui-surface, #fff);
   overflow: hidden;
   text-align: left;
 }
@@ -1190,7 +1350,7 @@ body > div:first-child {
   text-align: left;
   border: 1px solid var(--a2ui-border);
   border-radius: 9px;
-  background: var(--cre8-color-bg-default, #fff);
+  background: var(--ui-surface, #fff);
   padding: 11px 13px;
   font: inherit;
   font-size: 13.5px;
@@ -1235,7 +1395,7 @@ body > div:first-child {
   border-radius: 10px;
   font: inherit;
   font-size: 14px;
-  background: var(--cre8-color-bg-default, #fff);
+  background: var(--ui-surface, #fff);
   color: inherit;
 }
 .mention-input textarea:focus { outline: none; border-color: var(--a2ui-brand); }
@@ -1266,7 +1426,7 @@ body > div:first-child {
   right: 0;
   max-height: 320px;
   overflow-y: auto;
-  background: var(--cre8-color-bg-default, #fff);
+  background: var(--ui-surface, #fff);
   border: 1px solid var(--a2ui-border);
   border-radius: 12px;
   box-shadow: 0 16px 40px rgba(0, 0, 0, 0.16);
@@ -1322,7 +1482,7 @@ body > div:first-child {
   gap: 10px;
   padding: 8px 12px;
   border-bottom: 1px solid var(--a2ui-border);
-  background: var(--cre8-color-bg-default, #fff);
+  background: var(--ui-surface, #fff);
 }
 .app-renderer-title { font-size: 13px; font-weight: 600; }
 .app-renderer-tabs { display: flex; gap: 2px; margin-left: 8px; }
@@ -1374,4 +1534,496 @@ body > div:first-child {
   line-height: 1.5;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+/* ===========================================================================
+   App shell — slim icon rail + top bar (dark-first, refined)
+   =========================================================================== */
+.shell {
+  display: grid;
+  grid-template-columns: var(--ui-rail-w) 1fr;
+  height: 100vh;
+  overflow: hidden;
+  background: var(--ui-bg);
+}
+
+.rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--ui-s2);
+  padding: var(--ui-s3) 0;
+  background: var(--ui-surface);
+  border-right: 1px solid var(--ui-border-subtle);
+  z-index: 30;
+}
+.rail-brand {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  margin-bottom: var(--ui-s2);
+  border-radius: var(--ui-r-md);
+  background: linear-gradient(135deg, var(--ui-accent), var(--ui-accent-active));
+  color: var(--ui-accent-fg);
+  text-decoration: none;
+  box-shadow: var(--ui-shadow-sm);
+}
+.rail-brand-mark {
+  font-size: 14px;
+  font-weight: 800;
+  letter-spacing: -0.5px;
+}
+.rail-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+.rail-item {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--ui-r-md);
+  color: var(--ui-fg-muted);
+  text-decoration: none;
+  transition: background var(--ui-fast) var(--ui-ease), color var(--ui-fast) var(--ui-ease);
+}
+.rail-item:hover {
+  background: var(--ui-surface-2);
+  color: var(--ui-fg);
+}
+.rail-item.active {
+  background: var(--ui-accent-soft);
+  color: var(--ui-accent);
+}
+.rail-item.active::before {
+  content: "";
+  position: absolute;
+  left: -12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 20px;
+  border-radius: 0 3px 3px 0;
+  background: var(--ui-accent);
+}
+.rail-item[data-tip]::after {
+  content: attr(data-tip);
+  position: absolute;
+  left: calc(100% + 10px);
+  top: 50%;
+  transform: translateY(-50%) scale(0.96);
+  transform-origin: left center;
+  padding: 5px 9px;
+  background: var(--ui-surface-3);
+  color: var(--ui-fg);
+  border: 1px solid var(--ui-border);
+  border-radius: var(--ui-r-sm);
+  font-size: 12px;
+  white-space: nowrap;
+  box-shadow: var(--ui-shadow-md);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--ui-fast) var(--ui-ease), transform var(--ui-fast) var(--ui-ease);
+  z-index: 40;
+}
+.rail-item:hover[data-tip]::after {
+  opacity: 1;
+  transform: translateY(-50%) scale(1);
+}
+.rail-foot {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.theme-toggle {
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border: none;
+  background: none;
+  color: var(--ui-fg-muted);
+  border-radius: var(--ui-r-md);
+  cursor: pointer;
+  transition: background var(--ui-fast) var(--ui-ease), color var(--ui-fast) var(--ui-ease);
+}
+.theme-toggle:hover {
+  background: var(--ui-surface-2);
+  color: var(--ui-fg);
+}
+
+.shell-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: var(--ui-s4);
+  height: var(--ui-topbar-h);
+  flex: none;
+  padding: 0 var(--ui-s5);
+  border-bottom: 1px solid var(--ui-border-subtle);
+  background: color-mix(in srgb, var(--ui-bg) 80%, transparent);
+  backdrop-filter: blur(8px);
+}
+.topbar-titles {
+  display: flex;
+  align-items: baseline;
+  gap: var(--ui-s3);
+  min-width: 0;
+}
+.topbar-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 650;
+  letter-spacing: -0.1px;
+  white-space: nowrap;
+}
+.topbar-subtitle {
+  font-size: 12.5px;
+  color: var(--ui-fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.topbar-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--ui-s3);
+}
+.topbar-link {
+  font-size: 12.5px;
+  color: var(--ui-fg-muted);
+  text-decoration: none;
+  padding: 5px 10px;
+  border-radius: var(--ui-r-sm);
+  border: 1px solid var(--ui-border);
+  transition: color var(--ui-fast), border-color var(--ui-fast);
+}
+.topbar-link:hover {
+  color: var(--ui-fg);
+  border-color: var(--ui-border-strong);
+}
+.shell-content {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* page wrappers ----------------------------------------------------------- */
+.page {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.page--full > * {
+  flex: 1;
+  min-height: 0;
+}
+.page--center {
+  overflow-y: auto;
+  padding: var(--ui-s5);
+}
+.page--center > * {
+  max-width: 980px;
+  margin: 0 auto;
+  width: 100%;
+}
+.page--scroll {
+  overflow-y: auto;
+  padding: var(--ui-s5);
+}
+.page--scroll > * {
+  max-width: 1140px;
+  margin: 0 auto;
+  width: 100%;
+}
+.page--chat {
+  width: 100%;
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 0 var(--ui-s4);
+}
+
+@media (max-width: 720px) {
+  :root { --ui-rail-w: 52px; }
+  .topbar-subtitle { display: none; }
+}
+
+/* ===========================================================================
+   Artboard — agent-rendered cre8 components always sit on a light surface
+   so the (light-themed) cre8-a2ui tokens read correctly in any app theme.
+   =========================================================================== */
+.a2ui-canvas {
+  background: var(--ui-artboard);
+  color: var(--ui-artboard-ink);
+  border: 1px solid var(--ui-artboard-border);
+  border-radius: var(--ui-r-md);
+  padding: var(--ui-s4);
+}
+.app-renderer-canvas,
+.brand-preview-frame,
+.da-canvas-panel-inner,
+.da-canvas-inline {
+  background: var(--ui-artboard);
+  color: var(--ui-artboard-ink);
+}
+.app-renderer-canvas .a2ui-canvas,
+.brand-preview-frame .a2ui-canvas {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+}
+.preview-iframe,
+.stack-iframe,
+.stack-preview {
+  background: #fff;
+}
+
+/* ===========================================================================
+   Toasts
+   =========================================================================== */
+.toast-viewport {
+  position: fixed;
+  bottom: var(--ui-s5);
+  right: var(--ui-s5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ui-s2);
+  z-index: 1000;
+  pointer-events: none;
+}
+.toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--ui-s3);
+  min-width: 260px;
+  max-width: 380px;
+  padding: 11px 13px;
+  background: var(--ui-surface-3);
+  border: 1px solid var(--ui-border);
+  border-radius: var(--ui-r-md);
+  box-shadow: var(--ui-shadow-lg);
+  font-size: 13.5px;
+  animation: toast-in var(--ui-med) var(--ui-ease);
+}
+@keyframes toast-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.98); }
+  to { opacity: 1; transform: none; }
+}
+.toast-icon {
+  display: grid;
+  place-items: center;
+  width: 20px;
+  height: 20px;
+  flex: none;
+  border-radius: 50%;
+  font-size: 12px;
+  font-weight: 700;
+  color: #fff;
+}
+.toast-icon--success { background: var(--ui-success); }
+.toast-icon--error { background: var(--ui-danger); }
+.toast-icon--info { background: var(--ui-accent); color: var(--ui-accent-fg); }
+.toast-msg { flex: 1; }
+.toast-close {
+  border: none;
+  background: none;
+  color: var(--ui-fg-subtle);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 2px;
+}
+.toast-close:hover { color: var(--ui-fg); }
+
+/* ===========================================================================
+   Modal
+   =========================================================================== */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: var(--ui-overlay);
+  backdrop-filter: blur(3px);
+  display: grid;
+  place-items: center;
+  padding: var(--ui-s5);
+  z-index: 900;
+  animation: fade-in var(--ui-fast) var(--ui-ease);
+}
+@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+.modal {
+  width: 100%;
+  max-width: 440px;
+  background: var(--ui-surface);
+  border: 1px solid var(--ui-border);
+  border-radius: var(--ui-r-lg);
+  box-shadow: var(--ui-shadow-lg);
+  overflow: hidden;
+  animation: modal-in var(--ui-med) var(--ui-ease);
+}
+@keyframes modal-in {
+  from { opacity: 0; transform: translateY(12px) scale(0.98); }
+  to { opacity: 1; transform: none; }
+}
+.modal-head { padding: var(--ui-s5) var(--ui-s5) var(--ui-s3); }
+.modal-title { margin: 0; font-size: 17px; font-weight: 650; }
+.modal-desc { margin: 6px 0 0; font-size: 13.5px; color: var(--ui-fg-muted); line-height: 1.5; }
+.modal-body { padding: 0 var(--ui-s5) var(--ui-s4); display: flex; flex-direction: column; gap: var(--ui-s3); }
+.modal-foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--ui-s2);
+  padding: var(--ui-s4) var(--ui-s5);
+  border-top: 1px solid var(--ui-border-subtle);
+  background: var(--ui-surface-2);
+}
+.modal-field { display: flex; flex-direction: column; gap: 5px; }
+.modal-field label { font-size: 12px; font-weight: 600; color: var(--ui-fg-muted); }
+.modal-field input,
+.modal-field textarea {
+  width: 100%;
+  padding: 9px 11px;
+  background: var(--ui-bg);
+  border: 1px solid var(--ui-border);
+  border-radius: var(--ui-r-sm);
+  font: inherit;
+  font-size: 13.5px;
+  color: var(--ui-fg);
+}
+.modal-field input:focus,
+.modal-field textarea:focus { outline: none; border-color: var(--ui-accent); }
+
+/* shared button primitives (modal etc.) */
+.btn {
+  padding: 8px 15px;
+  border-radius: var(--ui-r-sm);
+  border: 1px solid var(--ui-border);
+  background: var(--ui-surface-3);
+  color: var(--ui-fg);
+  font: inherit;
+  font-size: 13.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--ui-fast), border-color var(--ui-fast), opacity var(--ui-fast);
+}
+.btn:hover { border-color: var(--ui-border-strong); }
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.btn--primary {
+  background: var(--ui-accent);
+  border-color: transparent;
+  color: var(--ui-accent-fg);
+}
+.btn--primary:hover { background: var(--ui-accent-hover); }
+.btn--ghost { background: transparent; }
+.btn--ghost:hover { background: var(--ui-surface-2); }
+
+/* ===========================================================================
+   Polish + shell-fit fixes (refined-product)
+   =========================================================================== */
+
+/* Home chat fills the shell content area: thread scrolls, composer pinned. */
+.page--chat .thread {
+  flex: 1;
+  min-height: 0;
+  padding: var(--ui-s5) 0;
+}
+.page--chat .composer {
+  flex: none;
+  border-top: 1px solid var(--ui-border-subtle);
+}
+
+/* Chat bubbles — calmer, more legible */
+.msg .role {
+  font-size: 10.5px;
+  letter-spacing: 0.6px;
+  color: var(--ui-fg-subtle);
+  opacity: 1;
+}
+.msg-assistant .bubble {
+  font-size: 14.5px;
+  line-height: 1.6;
+}
+.msg-user .bubble {
+  background: var(--ui-surface-2);
+  border-color: var(--ui-border);
+  border-radius: var(--ui-r-md);
+}
+.composer textarea {
+  background: var(--ui-surface);
+  border: 1px solid var(--ui-border);
+  border-radius: var(--ui-r-md);
+  color: var(--ui-fg);
+  transition: border-color var(--ui-fast);
+}
+.composer textarea:focus {
+  outline: none;
+  border-color: var(--ui-accent);
+}
+.composer button {
+  background: var(--ui-accent);
+  color: var(--ui-accent-fg);
+  border-radius: var(--ui-r-md);
+  transition: background var(--ui-fast);
+}
+.composer button:hover:not(:disabled) {
+  background: var(--ui-accent-hover);
+}
+
+/* Landing fits inside the scrollable content area (no double viewport height) */
+.a2ui-landing {
+  min-height: 100%;
+  padding: var(--ui-s6) 0;
+}
+.a2ui-choice-card {
+  background: var(--ui-surface);
+  border-color: var(--ui-border);
+}
+.a2ui-choice-card:hover {
+  border-color: var(--ui-accent);
+  box-shadow: var(--ui-shadow-md);
+}
+
+/* Mention-kind chips follow the category tokens */
+.mention-kind--pattern { background: var(--ui-accent-soft); color: var(--ui-cat-pattern); }
+.mention-kind--component { background: color-mix(in srgb, var(--ui-cat-component) 18%, transparent); color: var(--ui-cat-component); }
+.mention-kind--data { background: color-mix(in srgb, var(--ui-cat-data) 20%, transparent); color: var(--ui-cat-data); }
+.mention-token {
+  background: var(--ui-accent-soft);
+  color: var(--ui-accent);
+}
+
+/* Workspace surfaces */
+.workspace-grid { border-top-color: var(--ui-border-subtle); }
+.library-panel { background: var(--ui-surface); }
+.app-renderer { background: var(--ui-surface); }
+.workspace-starter:hover { border-color: var(--ui-accent); }
+
+/* Any embedded preview iframe renders a real document → keep it on white */
+.explore-canvas iframe,
+.explore-panel-body iframe,
+.explore-report-body iframe,
+.da-canvas-panel iframe {
+  background: #fff;
+  border-radius: var(--ui-r-sm);
+}
+
+/* Pipeline / status chips, builder code, agent logs — align to --ui */
+.builder-code,
+.app-renderer-spec {
+  background: var(--ui-bg);
+  color: var(--ui-fg);
 }

--- a/packages/cre8-studio/src/app/layout.tsx
+++ b/packages/cre8-studio/src/app/layout.tsx
@@ -1,15 +1,24 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import AppShell from "@/components/shell/app-shell";
 
 export const metadata: Metadata = {
   title: "cre8 studio",
   description: "A2UI chat powered by Claude + cre8-wc",
 };
 
+// Set the theme attribute before first paint to avoid a flash. Defaults to dark.
+const THEME_BOOT = `(function(){try{var t=localStorage.getItem('cre8-ui-theme');document.documentElement.dataset.theme=(t==='light'?'light':'dark');}catch(e){document.documentElement.dataset.theme='dark';}})();`;
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
-      <body>{children}</body>
+    <html lang="en" data-theme="dark" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: THEME_BOOT }} />
+      </head>
+      <body>
+        <AppShell>{children}</AppShell>
+      </body>
     </html>
   );
 }

--- a/packages/cre8-studio/src/app/page.tsx
+++ b/packages/cre8-studio/src/app/page.tsx
@@ -1,19 +1,9 @@
-import Link from "next/link";
 import Chat from "@/components/chat";
 
 export default function Home() {
   return (
-    <main className="app">
-      <header className="header">
-        <h1>cre8 studio</h1>
-        <span className="subtitle">Gemini + cre8-wc A2UI · streaming chat</span>
-        <Link href="/a2ui" className="header-nav-link">A2UI Demo →</Link>
-        <Link href="/build" className="header-nav-link">App Builder →</Link>
-        <Link href="/stack" className="header-nav-link">Stack →</Link>
-        <Link href="/data" className="header-nav-link">Data Agent →</Link>
-        <Link href="/explore" className="header-nav-link">Explore →</Link>
-      </header>
+    <div className="page page--chat">
       <Chat />
-    </main>
+    </div>
   );
 }

--- a/packages/cre8-studio/src/app/page.tsx
+++ b/packages/cre8-studio/src/app/page.tsx
@@ -7,6 +7,7 @@ export default function Home() {
       <header className="header">
         <h1>cre8 studio</h1>
         <span className="subtitle">Gemini + cre8-wc A2UI · streaming chat</span>
+        <Link href="/a2ui" className="header-nav-link">A2UI Demo →</Link>
         <Link href="/build" className="header-nav-link">App Builder →</Link>
         <Link href="/stack" className="header-nav-link">Stack →</Link>
         <Link href="/data" className="header-nav-link">Data Agent →</Link>

--- a/packages/cre8-studio/src/app/stack/page.tsx
+++ b/packages/cre8-studio/src/app/stack/page.tsx
@@ -1,15 +1,9 @@
-import Link from "next/link";
 import StackBuilder from "@/components/stack-builder";
 
 export default function StackPage() {
   return (
-    <main className="app app--fullbleed">
-      <header className="header">
-        <h1>cre8 stack</h1>
-        <span className="subtitle">chat · build · preview — full stack in one view</span>
-        <Link href="/" className="header-nav-link">← Studio</Link>
-      </header>
+    <div className="page page--full">
       <StackBuilder />
-    </main>
+    </div>
   );
 }

--- a/packages/cre8-studio/src/components/a2ui-demo/app-renderer.tsx
+++ b/packages/cre8-studio/src/components/a2ui-demo/app-renderer.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState } from "react";
+import type { ComponentSpec, EmittedEvent } from "@tmorrow/cre8-wc/a2ui";
+import { A2uiCanvas } from "@/components/a2ui-canvas";
+
+type Tab = "app" | "spec";
+
+// The right-hand "app renderer" — shows the latest UI the agent composed, full
+// size, with the ability to inspect the spec and save it as a reusable pattern.
+export default function AppRenderer({
+  spec,
+  onEvent,
+  onSave,
+  streaming,
+}: {
+  spec: ComponentSpec | null;
+  onEvent: (e: EmittedEvent) => void;
+  onSave: (spec: ComponentSpec) => void;
+  streaming: boolean;
+}) {
+  const [tab, setTab] = useState<Tab>("app");
+
+  return (
+    <section className="app-renderer">
+      <div className="app-renderer-bar">
+        <span className="app-renderer-title">App renderer</span>
+        <div className="app-renderer-tabs">
+          <button
+            className={tab === "app" ? "active" : ""}
+            onClick={() => setTab("app")}
+            disabled={!spec}
+          >
+            Preview
+          </button>
+          <button
+            className={tab === "spec" ? "active" : ""}
+            onClick={() => setTab("spec")}
+            disabled={!spec}
+          >
+            Spec
+          </button>
+        </div>
+        <button
+          className="app-renderer-save"
+          onClick={() => spec && onSave(spec)}
+          disabled={!spec}
+          title="Save the current UI as a reusable pattern"
+        >
+          ＋ Save as pattern
+        </button>
+      </div>
+
+      <div className="app-renderer-body">
+        {!spec && (
+          <div className="app-renderer-empty">
+            <div className="app-renderer-empty-glyph">▦</div>
+            <p>
+              {streaming
+                ? "Composing your UI…"
+                : "The app you build appears here. Ask the agent for a screen, form, dashboard or page — @mention components, patterns and data to steer it."}
+            </p>
+          </div>
+        )}
+        {spec && tab === "app" && (
+          <div className="app-renderer-canvas">
+            <A2uiCanvas spec={spec} onEvent={onEvent} />
+          </div>
+        )}
+        {spec && tab === "spec" && (
+          <pre className="app-renderer-spec">{JSON.stringify(spec, null, 2)}</pre>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/packages/cre8-studio/src/components/a2ui-demo/brand-extractor.tsx
+++ b/packages/cre8-studio/src/components/a2ui-demo/brand-extractor.tsx
@@ -8,6 +8,7 @@ import { applyTheme, scopedThemeCss } from "@/lib/a2ui-demo/theme";
 import { readableOn } from "@/lib/a2ui-demo/ramp";
 import { BRAND_PREVIEW_SPEC } from "@/lib/a2ui-demo/preview-spec";
 import { A2uiCanvas } from "@/components/a2ui-canvas";
+import { toast } from "@/components/shell/toast";
 
 type Status = "idle" | "loading" | "ready" | "error";
 
@@ -62,6 +63,7 @@ export default function BrandExtractor() {
     persistTheme(theme);
     applyTheme(theme);
     setSaved(true);
+    toast.success(`Applied “${theme.name}” across the workspace`);
   }, [theme]);
 
   const clearTheme = useCallback(() => {
@@ -70,6 +72,7 @@ export default function BrandExtractor() {
     setThemeState(null);
     setStatus("idle");
     setSaved(false);
+    toast("Reset to the default cre8 theme");
   }, []);
 
   // Scoped preview CSS so the comparison reflects the candidate theme without

--- a/packages/cre8-studio/src/components/a2ui-demo/brand-extractor.tsx
+++ b/packages/cre8-studio/src/components/a2ui-demo/brand-extractor.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import type { BrandTheme } from "@/lib/a2ui-demo/types";
+import { setTheme as persistTheme, getTheme } from "@/lib/a2ui-demo/store";
+import { applyTheme, scopedThemeCss } from "@/lib/a2ui-demo/theme";
+import { readableOn } from "@/lib/a2ui-demo/ramp";
+import { BRAND_PREVIEW_SPEC } from "@/lib/a2ui-demo/preview-spec";
+import { A2uiCanvas } from "@/components/a2ui-canvas";
+
+type Status = "idle" | "loading" | "ready" | "error";
+
+const PREVIEW_SELECTOR = "#brand-preview-root";
+
+export default function BrandExtractor() {
+  const router = useRouter();
+  const [url, setUrl] = useState("");
+  const [color, setColor] = useState("#7C3AED");
+  const [name, setName] = useState("");
+  const [status, setStatus] = useState<Status>("idle");
+  const [error, setError] = useState("");
+  const [theme, setThemeState] = useState<BrandTheme | null>(null);
+  const [candidates, setCandidates] = useState<string[]>([]);
+  const [saved, setSaved] = useState(false);
+
+  const extract = useCallback(
+    async (payload: { url?: string; primary?: string }) => {
+      setStatus("loading");
+      setError("");
+      setSaved(false);
+      try {
+        const res = await fetch("/api/brand-extract", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ...payload, name: name || undefined }),
+        });
+        const json = await res.json();
+        if (!res.ok) throw new Error(json.error || `HTTP ${res.status}`);
+        const t = json.theme as BrandTheme;
+        t.createdAt = Date.now();
+        setThemeState(t);
+        setColor(t.primary);
+        setCandidates((json.candidates as string[]) ?? []);
+        setStatus("ready");
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+        setStatus("error");
+      }
+    },
+    [name],
+  );
+
+  const onSubmitUrl = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!url.trim()) return;
+    void extract({ url: url.trim() });
+  };
+
+  const save = useCallback(() => {
+    if (!theme) return;
+    persistTheme(theme);
+    applyTheme(theme);
+    setSaved(true);
+  }, [theme]);
+
+  const clearTheme = useCallback(() => {
+    persistTheme(null);
+    applyTheme(null);
+    setThemeState(null);
+    setStatus("idle");
+    setSaved(false);
+  }, []);
+
+  // Scoped preview CSS so the comparison reflects the candidate theme without
+  // mutating the rest of the page until the user saves.
+  const previewCss = useMemo(
+    () => (theme ? scopedThemeCss(theme, PREVIEW_SELECTOR) : ""),
+    [theme],
+  );
+
+  const existing = getTheme();
+
+  return (
+    <div className="brand-extractor">
+      <div className="brand-controls">
+        <section className="brand-card">
+          <h3>From a website</h3>
+          <p className="brand-hint">
+            We fetch the page and pull its dominant brand color + font.
+          </p>
+          <form className="brand-row" onSubmit={onSubmitUrl}>
+            <input
+              type="text"
+              placeholder="stripe.com"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              disabled={status === "loading"}
+            />
+            <button type="submit" disabled={status === "loading" || !url.trim()}>
+              {status === "loading" ? "Extracting…" : "Extract"}
+            </button>
+          </form>
+        </section>
+
+        <section className="brand-card">
+          <h3>Or pick a color</h3>
+          <p className="brand-hint">Generate a full token ramp from one brand color.</p>
+          <div className="brand-row">
+            <input
+              type="color"
+              value={color}
+              onChange={(e) => setColor(e.target.value)}
+              className="brand-color-input"
+              aria-label="Brand color"
+            />
+            <input
+              type="text"
+              value={color}
+              onChange={(e) => setColor(e.target.value)}
+              className="brand-hex-input"
+              aria-label="Brand hex"
+            />
+            <button type="button" onClick={() => extract({ primary: color })}>
+              Generate
+            </button>
+          </div>
+          <div className="brand-row">
+            <input
+              type="text"
+              placeholder="Theme name (optional)"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+        </section>
+
+        {existing && (
+          <section className="brand-card brand-card--active">
+            <h3>Active theme</h3>
+            <div className="brand-active-row">
+              <span className="brand-dot" style={{ background: existing.primary }} />
+              <span>{existing.name}</span>
+              <button type="button" className="brand-link-btn" onClick={clearTheme}>
+                Reset to cre8 default
+              </button>
+            </div>
+          </section>
+        )}
+      </div>
+
+      {status === "error" && <pre className="a2ui-canvas-error">{error}</pre>}
+
+      {theme && (
+        <div className="brand-result">
+          <style dangerouslySetInnerHTML={{ __html: previewCss }} />
+
+          <div className="brand-meta">
+            <div className="brand-meta-head">
+              <h2>{theme.name}</h2>
+              {theme.source && <span className="brand-source">from {theme.source}</span>}
+            </div>
+
+            <div className="brand-ramp">
+              {theme.ramp.map((hex, i) => (
+                <div key={i} className="ramp-step" style={{ background: hex }} title={hex}>
+                  <span style={{ color: readableOn(hex) }}>{i === 5 ? "★" : ""}</span>
+                </div>
+              ))}
+            </div>
+
+            <div className="brand-facts">
+              <span>
+                <strong>Primary</strong> {theme.primary}
+              </span>
+              {theme.fontFamily && (
+                <span>
+                  <strong>Font</strong> {theme.fontFamily}
+                </span>
+              )}
+            </div>
+
+            {candidates.length > 1 && (
+              <div className="brand-candidates">
+                <span className="brand-hint">Other colors found — click to use:</span>
+                <div className="brand-swatches">
+                  {candidates.map((c) => (
+                    <button
+                      key={c}
+                      type="button"
+                      className="brand-swatch"
+                      style={{ background: c }}
+                      title={c}
+                      onClick={() => extract({ primary: c })}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="brand-actions">
+              <button type="button" className="brand-primary-btn" onClick={save}>
+                {saved ? "✓ Saved & applied" : "Apply theme"}
+              </button>
+              {saved && (
+                <button
+                  type="button"
+                  className="brand-primary-btn brand-go-btn"
+                  onClick={() => router.push("/a2ui/workspace")}
+                >
+                  Open workspace →
+                </button>
+              )}
+            </div>
+          </div>
+
+          <div className="brand-preview">
+            <div className="brand-preview-label">Live preview</div>
+            <div id="brand-preview-root" className="brand-preview-frame">
+              <A2uiCanvas spec={BRAND_PREVIEW_SPEC} onEvent={() => {}} />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/cre8-studio/src/components/a2ui-demo/library-panel.tsx
+++ b/packages/cre8-studio/src/components/a2ui-demo/library-panel.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { CatalogComponent, DataSource, Mention, Pattern } from "@/lib/a2ui-demo/types";
+
+type Tab = "patterns" | "components" | "data";
+
+// Left sidebar listing the three prepopulated, @-mentionable libraries. Clicking
+// an item inserts it as a mention into the composer.
+export default function LibraryPanel({
+  patterns,
+  components,
+  dataSources,
+  onMention,
+  onPreviewPattern,
+  onDeletePattern,
+}: {
+  patterns: Pattern[];
+  components: CatalogComponent[];
+  dataSources: DataSource[];
+  onMention: (m: Mention) => void;
+  onPreviewPattern: (p: Pattern) => void;
+  onDeletePattern: (id: string) => void;
+}) {
+  const [tab, setTab] = useState<Tab>("patterns");
+  const [q, setQ] = useState("");
+
+  const query = q.trim().toLowerCase();
+  const fPatterns = useMemo(
+    () => patterns.filter((p) => match(query, p.name, p.description, p.category)),
+    [patterns, query],
+  );
+  const fComponents = useMemo(
+    () => components.filter((c) => match(query, c.name, c.description, c.category)),
+    [components, query],
+  );
+  const fData = useMemo(
+    () => dataSources.filter((d) => match(query, d.name, d.description)),
+    [dataSources, query],
+  );
+
+  const counts = {
+    patterns: patterns.length,
+    components: components.length,
+    data: dataSources.length,
+  };
+
+  return (
+    <aside className="library-panel">
+      <div className="library-tabs">
+        <button className={tab === "patterns" ? "active" : ""} onClick={() => setTab("patterns")}>
+          Patterns <span>{counts.patterns}</span>
+        </button>
+        <button className={tab === "components" ? "active" : ""} onClick={() => setTab("components")}>
+          Components <span>{counts.components}</span>
+        </button>
+        <button className={tab === "data" ? "active" : ""} onClick={() => setTab("data")}>
+          Data <span>{counts.data}</span>
+        </button>
+      </div>
+
+      <input
+        className="library-search"
+        placeholder={`Search ${tab}…`}
+        value={q}
+        onChange={(e) => setQ(e.target.value)}
+      />
+
+      <div className="library-list">
+        {tab === "patterns" &&
+          fPatterns.map((p) => (
+            <div key={p.id} className="library-item">
+              <button
+                className="library-item-main"
+                onClick={() =>
+                  onMention({ kind: "pattern", id: p.id, label: tokenize(p.name) })
+                }
+                title="Insert @mention"
+              >
+                <span className="library-item-title">
+                  {p.name}
+                  {p.builtin ? (
+                    <span className="library-badge">built-in</span>
+                  ) : (
+                    <span className="library-badge library-badge--user">saved</span>
+                  )}
+                </span>
+                <span className="library-item-detail">{p.description}</span>
+              </button>
+              <div className="library-item-actions">
+                <button onClick={() => onPreviewPattern(p)} title="Preview in renderer">
+                  ▦
+                </button>
+                {!p.builtin && (
+                  <button onClick={() => onDeletePattern(p.id)} title="Delete">
+                    ✕
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+
+        {tab === "components" &&
+          fComponents.map((c) => (
+            <button
+              key={c.name}
+              className="library-item library-item--compact"
+              onClick={() => onMention({ kind: "component", id: c.name, label: c.name })}
+              title="Insert @mention"
+            >
+              <span className="library-item-title">{c.name}</span>
+              <span className="library-item-detail">{c.description || c.category}</span>
+            </button>
+          ))}
+
+        {tab === "data" &&
+          fData.map((d) => (
+            <button
+              key={d.id}
+              className="library-item library-item--compact"
+              onClick={() => onMention({ kind: "data", id: d.id, label: tokenize(d.name) })}
+              title="Insert @mention"
+            >
+              <span className="library-item-title">
+                {d.name}
+                {!d.builtin && <span className="library-badge library-badge--user">saved</span>}
+              </span>
+              <span className="library-item-detail">
+                {d.columns.length} cols · {d.description}
+              </span>
+            </button>
+          ))}
+      </div>
+    </aside>
+  );
+}
+
+function match(q: string, ...fields: (string | undefined)[]): boolean {
+  if (!q) return true;
+  return fields.some((f) => f?.toLowerCase().includes(q));
+}
+
+function tokenize(s: string): string {
+  return s.trim().replace(/\s+/g, "-");
+}

--- a/packages/cre8-studio/src/components/a2ui-demo/mention-input.tsx
+++ b/packages/cre8-studio/src/components/a2ui-demo/mention-input.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { Mention } from "@/lib/a2ui-demo/types";
+import type { MentionItem } from "@/lib/a2ui-demo/mentions";
+
+const KIND_LABEL: Record<Mention["kind"], string> = {
+  pattern: "Patterns",
+  component: "Components",
+  data: "Data sources",
+};
+const KIND_ICON: Record<Mention["kind"], string> = {
+  pattern: "▣",
+  component: "◈",
+  data: "▤",
+};
+
+export default function MentionInput({
+  value,
+  onChange,
+  onSend,
+  onAddMention,
+  items,
+  disabled,
+  placeholder,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  onSend: () => void;
+  onAddMention: (m: Mention) => void;
+  items: MentionItem[];
+  disabled?: boolean;
+  placeholder?: string;
+}) {
+  const taRef = useRef<HTMLTextAreaElement>(null);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [active, setActive] = useState(0);
+  const [anchor, setAnchor] = useState(0); // index of the triggering '@'
+
+  // Find an active @query immediately before the caret (word with no spaces).
+  const detectTrigger = (text: string, caret: number) => {
+    const upto = text.slice(0, caret);
+    const at = upto.lastIndexOf("@");
+    if (at === -1) return null;
+    const between = upto.slice(at + 1);
+    if (/\s/.test(between)) return null; // space ends a mention token
+    // require @ to be at start or preceded by whitespace
+    if (at > 0 && !/\s/.test(upto[at - 1])) return null;
+    return { at, query: between };
+  };
+
+  const filtered = open
+    ? items
+        .filter((it) => {
+          const q = query.toLowerCase();
+          return (
+            it.label.toLowerCase().includes(q) ||
+            it.title.toLowerCase().includes(q) ||
+            it.detail.toLowerCase().includes(q)
+          );
+        })
+        .slice(0, 24)
+    : [];
+
+  // Group filtered items by kind for display, preserving order.
+  const grouped: { kind: Mention["kind"]; items: MentionItem[] }[] = [];
+  for (const kind of ["pattern", "component", "data"] as const) {
+    const group = filtered.filter((it) => it.kind === kind);
+    if (group.length) grouped.push({ kind, items: group });
+  }
+  const flat = grouped.flatMap((g) => g.items);
+
+  useEffect(() => {
+    if (active >= flat.length) setActive(0);
+  }, [flat.length, active]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const text = e.target.value;
+    onChange(text);
+    const caret = e.target.selectionStart ?? text.length;
+    const trig = detectTrigger(text, caret);
+    if (trig) {
+      setOpen(true);
+      setQuery(trig.query);
+      setAnchor(trig.at);
+      setActive(0);
+    } else {
+      setOpen(false);
+    }
+  };
+
+  const pick = (it: MentionItem) => {
+    const ta = taRef.current;
+    const caret = ta?.selectionStart ?? value.length;
+    const before = value.slice(0, anchor);
+    const after = value.slice(caret);
+    const insert = `@${it.label} `;
+    const next = before + insert + after;
+    onChange(next);
+    onAddMention({ kind: it.kind, id: it.id, label: it.label });
+    setOpen(false);
+    setQuery("");
+    requestAnimationFrame(() => {
+      ta?.focus();
+      const pos = (before + insert).length;
+      ta?.setSelectionRange(pos, pos);
+    });
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (open && flat.length) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActive((a) => (a + 1) % flat.length);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActive((a) => (a - 1 + flat.length) % flat.length);
+        return;
+      }
+      if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        pick(flat[active]);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setOpen(false);
+        return;
+      }
+    }
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      if (!disabled && value.trim()) onSend();
+    }
+  };
+
+  return (
+    <div className="mention-input">
+      {open && flat.length > 0 && (
+        <div className="mention-menu">
+          {grouped.map((g) => (
+            <div key={g.kind} className="mention-group">
+              <div className="mention-group-head">{KIND_LABEL[g.kind]}</div>
+              {g.items.map((it) => {
+                const idx = flat.indexOf(it);
+                return (
+                  <button
+                    type="button"
+                    key={`${it.kind}:${it.id}`}
+                    className={`mention-option${idx === active ? " active" : ""}`}
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      pick(it);
+                    }}
+                    onMouseEnter={() => setActive(idx)}
+                  >
+                    <span className={`mention-kind mention-kind--${it.kind}`}>
+                      {KIND_ICON[it.kind]}
+                    </span>
+                    <span className="mention-option-text">
+                      <span className="mention-option-title">{it.title}</span>
+                      <span className="mention-option-detail">{it.detail}</span>
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      )}
+      <textarea
+        ref={taRef}
+        value={value}
+        onChange={handleChange}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder ?? "Describe a UI… type @ to reference patterns, components or data"}
+        disabled={disabled}
+        rows={3}
+      />
+      <div className="mention-input-foot">
+        <span className="mention-tip">
+          <kbd>@</kbd> to mention · <kbd>↵</kbd> to send · <kbd>⇧↵</kbd> newline
+        </span>
+        <button type="button" onClick={onSend} disabled={disabled || !value.trim()}>
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/cre8-studio/src/components/a2ui-demo/theme-boot.tsx
+++ b/packages/cre8-studio/src/components/a2ui-demo/theme-boot.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect } from "react";
+import { getTheme, onStoreChange } from "@/lib/a2ui-demo/store";
+import { applyTheme } from "@/lib/a2ui-demo/theme";
+
+// Applies any saved brand theme to the document on mount and keeps it in sync
+// when the theme changes (e.g. the extractor saves a new one). Mounted once per
+// A2UI route via the layout.
+export default function ThemeBoot() {
+  useEffect(() => {
+    applyTheme(getTheme());
+    return onStoreChange(() => applyTheme(getTheme()));
+  }, []);
+  return null;
+}

--- a/packages/cre8-studio/src/components/a2ui-demo/workspace.tsx
+++ b/packages/cre8-studio/src/components/a2ui-demo/workspace.tsx
@@ -29,6 +29,8 @@ import {
 import LibraryPanel from "./library-panel";
 import MentionInput from "./mention-input";
 import AppRenderer from "./app-renderer";
+import Modal from "@/components/shell/modal";
+import { toast } from "@/components/shell/toast";
 
 // ---- chat wire model (mirrors components/chat.tsx) -------------------------
 
@@ -132,6 +134,11 @@ export default function Workspace() {
   const [patterns, setPatterns] = useState<Pattern[]>([]);
   const [dataSources, setDataSources] = useState<DataSource[]>([]);
   const components = useMemo<CatalogComponent[]>(() => getCatalogComponents(), []);
+
+  // Save-as-pattern modal
+  const [saveTarget, setSaveTarget] = useState<ComponentSpec | null>(null);
+  const [saveName, setSaveName] = useState("");
+  const [saveDesc, setSaveDesc] = useState("");
 
   const threadRef = useRef<HTMLDivElement>(null);
 
@@ -339,13 +346,23 @@ export default function Workspace() {
 
   // ---- pattern save / preview ---------------------------------------------
 
-  const saveCurrentAsPattern = useCallback((spec: ComponentSpec) => {
-    const name = window.prompt("Name this pattern (saved to your library):");
-    if (!name?.trim()) return;
-    const description =
-      window.prompt("Short description (optional):")?.trim() || "Saved from the workspace.";
-    savePattern({ name: name.trim(), description, category: "Saved", spec });
+  const openSaveModal = useCallback((spec: ComponentSpec) => {
+    setSaveTarget(spec);
+    setSaveName("");
+    setSaveDesc("");
   }, []);
+
+  const confirmSave = useCallback(() => {
+    if (!saveTarget || !saveName.trim()) return;
+    savePattern({
+      name: saveName.trim(),
+      description: saveDesc.trim() || "Saved from the workspace.",
+      category: "Saved",
+      spec: saveTarget,
+    });
+    setSaveTarget(null);
+    toast.success(`Saved “${saveName.trim()}” to your patterns`);
+  }, [saveTarget, saveName, saveDesc]);
 
   // Preview a library pattern by injecting it as a synthetic assistant UI block.
   const previewPattern = useCallback((p: Pattern) => {
@@ -367,7 +384,10 @@ export default function Workspace() {
         dataSources={dataSources}
         onMention={addMention}
         onPreviewPattern={previewPattern}
-        onDeletePattern={(id) => deletePattern(id)}
+        onDeletePattern={(id) => {
+          deletePattern(id);
+          toast("Pattern deleted");
+        }}
       />
 
       <div className="workspace-chat">
@@ -453,8 +473,52 @@ export default function Workspace() {
         spec={current?.spec ?? null}
         streaming={streaming}
         onEvent={(e) => current && handleCanvasEvent(e, current.id)}
-        onSave={saveCurrentAsPattern}
+        onSave={openSaveModal}
       />
+
+      <Modal
+        open={saveTarget !== null}
+        title="Save as pattern"
+        description="Store the current UI in your library to @-mention and reuse later."
+        onClose={() => setSaveTarget(null)}
+        footer={
+          <>
+            <button type="button" className="btn btn--ghost" onClick={() => setSaveTarget(null)}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="btn btn--primary"
+              onClick={confirmSave}
+              disabled={!saveName.trim()}
+            >
+              Save pattern
+            </button>
+          </>
+        }
+      >
+        <div className="modal-field">
+          <label htmlFor="pattern-name">Name</label>
+          <input
+            id="pattern-name"
+            value={saveName}
+            onChange={(e) => setSaveName(e.target.value)}
+            placeholder="e.g. Orders table"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && saveName.trim()) confirmSave();
+            }}
+          />
+        </div>
+        <div className="modal-field">
+          <label htmlFor="pattern-desc">Description</label>
+          <input
+            id="pattern-desc"
+            value={saveDesc}
+            onChange={(e) => setSaveDesc(e.target.value)}
+            placeholder="Optional — what is this pattern for?"
+          />
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/packages/cre8-studio/src/components/a2ui-demo/workspace.tsx
+++ b/packages/cre8-studio/src/components/a2ui-demo/workspace.tsx
@@ -1,0 +1,474 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ComponentSpec, EmittedEvent } from "@tmorrow/cre8-wc/a2ui";
+import type {
+  CatalogComponent,
+  DataSource,
+  Mention,
+  Pattern,
+} from "@/lib/a2ui-demo/types";
+import { getCatalogComponents } from "@/lib/a2ui-demo/component-catalog";
+import {
+  buildMentionContext,
+  componentItem,
+  dataItem,
+  patternItem,
+  reconcileMentions,
+  type MentionItem,
+} from "@/lib/a2ui-demo/mentions";
+import {
+  deleteDataSource,
+  deletePattern,
+  getDataSources,
+  loadBuiltinPatterns,
+  mergePatterns,
+  onStoreChange,
+  savePattern,
+} from "@/lib/a2ui-demo/store";
+import LibraryPanel from "./library-panel";
+import MentionInput from "./mention-input";
+import AppRenderer from "./app-renderer";
+
+// ---- chat wire model (mirrors components/chat.tsx) -------------------------
+
+type UiBlock =
+  | { kind: "text"; text: string }
+  | { kind: "thinking"; text: string }
+  | { kind: "ui"; id: string; spec: ComponentSpec; caption?: string; consumed?: boolean }
+  | { kind: "error"; text: string };
+
+type UserBlock =
+  | { kind: "text"; text: string; display?: string }
+  | { kind: "tool_result"; tool_use_id: string; label: string; payload: Record<string, unknown> };
+
+type ChatMessage =
+  | { role: "user"; blocks: UserBlock[] }
+  | { role: "assistant"; blocks: UiBlock[] };
+
+type WireContent =
+  | { type: "text"; text: string }
+  | { type: "tool_use"; id: string; name: "render_ui"; input: { spec: ComponentSpec; caption?: string } }
+  | { type: "tool_result"; tool_use_id: string; content: string };
+type WireMessage = { role: "user" | "assistant"; content: WireContent[] };
+
+function toWire(messages: ChatMessage[]): WireMessage[] {
+  return messages.map((m): WireMessage => {
+    if (m.role === "user") {
+      const content: WireContent[] = [];
+      for (const b of m.blocks)
+        if (b.kind === "tool_result")
+          content.push({ type: "tool_result", tool_use_id: b.tool_use_id, content: JSON.stringify(b.payload) });
+      for (const b of m.blocks)
+        if (b.kind === "text" && b.text) content.push({ type: "text", text: b.text });
+      if (content.length === 0) content.push({ type: "text", text: "" });
+      return { role: "user", content };
+    }
+    const content: WireContent[] = [];
+    for (const b of m.blocks) {
+      if (b.kind === "text" && b.text) content.push({ type: "text", text: b.text });
+      if (b.kind === "ui")
+        content.push({ type: "tool_use", id: b.id, name: "render_ui", input: { spec: b.spec, caption: b.caption } });
+    }
+    if (content.length === 0) content.push({ type: "text", text: "" });
+    return { role: "assistant", content };
+  });
+}
+
+function pendingToolUses(messages: ChatMessage[]): Array<{ id: string }> {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m.role === "user") break;
+    if (m.role === "assistant")
+      return m.blocks
+        .filter((b): b is Extract<UiBlock, { kind: "ui" }> => b.kind === "ui" && !b.consumed)
+        .map((b) => ({ id: b.id }));
+  }
+  return [];
+}
+
+function markConsumed(messages: ChatMessage[], ids: Set<string>): ChatMessage[] {
+  const copy = [...messages];
+  for (let i = copy.length - 1; i >= 0; i--) {
+    const m = copy[i];
+    if (m.role === "assistant") {
+      copy[i] = {
+        role: "assistant",
+        blocks: m.blocks.map((b) => (b.kind === "ui" && ids.has(b.id) ? { ...b, consumed: true } : b)),
+      };
+      return copy;
+    }
+  }
+  return copy;
+}
+
+// Most recent UI spec the agent produced — drives the renderer panel.
+function latestSpec(messages: ChatMessage[]): { id: string; spec: ComponentSpec } | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m.role !== "assistant") continue;
+    for (let j = m.blocks.length - 1; j >= 0; j--) {
+      const b = m.blocks[j];
+      if (b.kind === "ui") return { id: b.id, spec: b.spec };
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+
+const STARTERS = [
+  "Build a user management table from @users with role badges and a search field",
+  "Create a product gallery from @products as cards with price and rating",
+  "Build a support dashboard from @support_tickets with priority badges",
+];
+
+export default function Workspace() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [mentions, setMentions] = useState<Mention[]>([]);
+  const [streaming, setStreaming] = useState(false);
+
+  const [patterns, setPatterns] = useState<Pattern[]>([]);
+  const [dataSources, setDataSources] = useState<DataSource[]>([]);
+  const components = useMemo<CatalogComponent[]>(() => getCatalogComponents(), []);
+
+  const threadRef = useRef<HTMLDivElement>(null);
+
+  // Load libraries (builtin patterns from API + user items from localStorage).
+  useEffect(() => {
+    let alive = true;
+    const refresh = async () => {
+      const builtins = await loadBuiltinPatterns();
+      if (!alive) return;
+      setPatterns(mergePatterns(builtins));
+      setDataSources(getDataSources());
+    };
+    void refresh();
+    return onStoreChange(() => {
+      // builtins are cached; merge with latest user items synchronously
+      void loadBuiltinPatterns().then((b) => alive && setPatterns(mergePatterns(b)));
+      if (alive) setDataSources(getDataSources());
+    });
+  }, []);
+
+  useEffect(() => {
+    const el = threadRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages, streaming]);
+
+  const mentionItems = useMemo<MentionItem[]>(
+    () => [
+      ...patterns.map(patternItem),
+      ...components.map(componentItem),
+      ...dataSources.map(dataItem),
+    ],
+    [patterns, components, dataSources],
+  );
+
+  const addMention = useCallback(
+    (m: Mention) => {
+      setMentions((prev) =>
+        prev.some((x) => x.kind === m.kind && x.id === m.id) ? prev : [...prev, m],
+      );
+      // When inserted from the library (not the inline @ menu), append the token.
+      setInput((prev) => (prev.includes(`@${m.label}`) ? prev : `${prev}${prev && !prev.endsWith(" ") ? " " : ""}@${m.label} `));
+    },
+    [],
+  );
+
+  const postTurn = useCallback(async (history: ChatMessage[]) => {
+    setStreaming(true);
+    try {
+      const res = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: toWire(history) }),
+      });
+      if (!res.ok || !res.body) throw new Error(`HTTP ${res.status}`);
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      const pushBlock = (fn: (blocks: UiBlock[]) => UiBlock[]) => {
+        setMessages((prev) => {
+          const copy = [...prev];
+          const last = copy[copy.length - 1];
+          if (last?.role !== "assistant") return prev;
+          copy[copy.length - 1] = { role: "assistant", blocks: fn(last.blocks) };
+          return copy;
+        });
+      };
+
+      const handleEvent = (event: string, data: unknown) => {
+        switch (event) {
+          case "text": {
+            const { delta } = data as { delta: string };
+            pushBlock((blocks) => {
+              const last = blocks[blocks.length - 1];
+              if (last?.kind === "text")
+                return [...blocks.slice(0, -1), { kind: "text", text: last.text + delta }];
+              return [...blocks, { kind: "text", text: delta }];
+            });
+            break;
+          }
+          case "thinking": {
+            const { delta } = data as { delta: string };
+            pushBlock((blocks) => {
+              const last = blocks[blocks.length - 1];
+              if (last?.kind === "thinking")
+                return [...blocks.slice(0, -1), { kind: "thinking", text: last.text + delta }];
+              return [...blocks, { kind: "thinking", text: delta }];
+            });
+            break;
+          }
+          case "tool_use": {
+            const { id, spec, caption } = data as { id: string; spec: ComponentSpec; caption?: string };
+            pushBlock((blocks) => [...blocks, { kind: "ui", id, spec, caption }]);
+            break;
+          }
+          case "tool_use_error": {
+            const { error } = data as { error: string };
+            pushBlock((blocks) => [...blocks, { kind: "error", text: `Spec validation failed:\n${error}` }]);
+            break;
+          }
+          case "error": {
+            const { message } = data as { message: string };
+            pushBlock((blocks) => [...blocks, { kind: "error", text: message }]);
+            break;
+          }
+        }
+      };
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        let idx;
+        while ((idx = buffer.indexOf("\n\n")) !== -1) {
+          const frame = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + 2);
+          let event = "message";
+          let dataStr = "";
+          for (const line of frame.split("\n")) {
+            if (line.startsWith("event: ")) event = line.slice(7);
+            else if (line.startsWith("data: ")) dataStr += line.slice(6);
+          }
+          if (dataStr) {
+            try {
+              handleEvent(event, JSON.parse(dataStr));
+            } catch {
+              /* ignore malformed frame */
+            }
+          }
+        }
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setMessages((prev) => {
+        const copy = [...prev];
+        const last = copy[copy.length - 1];
+        if (last?.role !== "assistant") return prev;
+        copy[copy.length - 1] = { role: "assistant", blocks: [...last.blocks, { kind: "error", text: msg }] };
+        return copy;
+      });
+    } finally {
+      setStreaming(false);
+    }
+  }, []);
+
+  const send = useCallback(
+    (rawText: string) => {
+      const text = rawText.trim();
+      if (!text || streaming) return;
+
+      const active = reconcileMentions(text, mentions);
+      const context = buildMentionContext(active, { patterns, components, dataSources });
+
+      const pending = pendingToolUses(messages);
+      const userBlocks: UserBlock[] = pending.map((p) => ({
+        kind: "tool_result" as const,
+        tool_use_id: p.id,
+        label: "User sent a new message instead.",
+        payload: { event: "dismissed" },
+      }));
+      // `display` is the visible text; `text` (sent to model) carries context.
+      userBlocks.push({ kind: "text", text: text + context, display: text });
+
+      const consumed = new Set(pending.map((p) => p.id));
+      const base = markConsumed(messages, consumed);
+      const next: ChatMessage[] = [
+        ...base,
+        { role: "user", blocks: userBlocks },
+        { role: "assistant", blocks: [] },
+      ];
+      setMessages(next);
+      setInput("");
+      setMentions([]);
+      void postTurn(next.slice(0, -1));
+    },
+    [messages, mentions, patterns, components, dataSources, streaming, postTurn],
+  );
+
+  const handleCanvasEvent = useCallback(
+    (e: EmittedEvent, toolUseId: string) => {
+      if (streaming) return;
+      const pending = pendingToolUses(messages);
+      if (!pending.some((p) => p.id === toolUseId)) return;
+
+      const payload: Record<string, unknown> = { event: e.event, handler: e.handler, component: e.component };
+      if (e.detail !== undefined) payload.detail = e.detail;
+
+      const userBlocks: UserBlock[] = pending.map((p) =>
+        p.id === toolUseId
+          ? { kind: "tool_result" as const, tool_use_id: p.id, label: `${e.handler || e.event} · ${e.component}`, payload }
+          : { kind: "tool_result" as const, tool_use_id: p.id, label: "Dismissed", payload: { event: "dismissed" } },
+      );
+      const consumed = new Set(pending.map((p) => p.id));
+      const base = markConsumed(messages, consumed);
+      const next: ChatMessage[] = [
+        ...base,
+        { role: "user", blocks: userBlocks },
+        { role: "assistant", blocks: [] },
+      ];
+      setMessages(next);
+      void postTurn(next.slice(0, -1));
+    },
+    [messages, streaming, postTurn],
+  );
+
+  // ---- pattern save / preview ---------------------------------------------
+
+  const saveCurrentAsPattern = useCallback((spec: ComponentSpec) => {
+    const name = window.prompt("Name this pattern (saved to your library):");
+    if (!name?.trim()) return;
+    const description =
+      window.prompt("Short description (optional):")?.trim() || "Saved from the workspace.";
+    savePattern({ name: name.trim(), description, category: "Saved", spec });
+  }, []);
+
+  // Preview a library pattern by injecting it as a synthetic assistant UI block.
+  const previewPattern = useCallback((p: Pattern) => {
+    const id = `preview_${p.id}_${messages.length}`;
+    setMessages((prev) => [
+      ...prev,
+      { role: "user", blocks: [{ kind: "text", text: `Preview pattern: ${p.name}`, display: `Preview pattern: ${p.name}` }] },
+      { role: "assistant", blocks: [{ kind: "ui", id, spec: p.spec, caption: `${p.name} (pattern preview)`, consumed: true }] },
+    ]);
+  }, [messages.length]);
+
+  const current = latestSpec(messages);
+
+  return (
+    <div className="workspace-grid">
+      <LibraryPanel
+        patterns={patterns}
+        components={components}
+        dataSources={dataSources}
+        onMention={addMention}
+        onPreviewPattern={previewPattern}
+        onDeletePattern={(id) => deletePattern(id)}
+      />
+
+      <div className="workspace-chat">
+        <div className="thread" ref={threadRef}>
+          {messages.length === 0 && (
+            <div className="workspace-empty">
+              <p className="workspace-empty-lead">
+                Describe an app and the agent composes it with cre8-wc. Use{" "}
+                <strong>@</strong> to reference patterns, components or data.
+              </p>
+              <div className="workspace-starters">
+                {STARTERS.map((s) => (
+                  <button key={s} onClick={() => send(s)} className="workspace-starter">
+                    {s}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+          {messages.map((m, i) => (
+            <div key={i} className={`msg msg-${m.role}`}>
+              <span className="role">{m.role}</span>
+              {m.role === "user"
+                ? m.blocks.map((b, j) => {
+                    if (b.kind === "text")
+                      return (
+                        <div key={j} className="bubble">
+                          {renderMentions(b.display ?? b.text)}
+                        </div>
+                      );
+                    return (
+                      <div key={j} className="bubble bubble-action">
+                        <div className="action-label">{b.label}</div>
+                        <pre className="action-payload">{JSON.stringify(b.payload, null, 2)}</pre>
+                      </div>
+                    );
+                  })
+                : m.blocks.map((b, j) => {
+                    if (b.kind === "text")
+                      return (
+                        <div key={j} className="bubble">
+                          {b.text}
+                        </div>
+                      );
+                    if (b.kind === "thinking")
+                      return (
+                        <div key={j} className="bubble thinking">
+                          {b.text}
+                        </div>
+                      );
+                    if (b.kind === "error")
+                      return (
+                        <pre key={j} className="a2ui-canvas-error">
+                          {b.text}
+                        </pre>
+                      );
+                    // ui block — shown in the renderer, marked inline in the thread
+                    return (
+                      <div key={j} className="bubble bubble-rendered">
+                        {b.caption ? b.caption : "Composed UI"}
+                        <span className="bubble-rendered-tag">→ renderer</span>
+                      </div>
+                    );
+                  })}
+            </div>
+          ))}
+          {streaming && <div className="workspace-streaming">agent is working…</div>}
+        </div>
+
+        <div className="workspace-composer">
+          <MentionInput
+            value={input}
+            onChange={setInput}
+            onSend={() => send(input)}
+            onAddMention={addMention}
+            items={mentionItems}
+            disabled={streaming}
+          />
+        </div>
+      </div>
+
+      <AppRenderer
+        spec={current?.spec ?? null}
+        streaming={streaming}
+        onEvent={(e) => current && handleCanvasEvent(e, current.id)}
+        onSave={saveCurrentAsPattern}
+      />
+    </div>
+  );
+}
+
+// Highlight @tokens in the visible user bubble.
+function renderMentions(text: string): React.ReactNode {
+  const parts = text.split(/(@[A-Za-z0-9_-]+)/g);
+  return parts.map((part, i) =>
+    /^@[A-Za-z0-9_-]+$/.test(part) ? (
+      <span key={i} className="mention-token">
+        {part}
+      </span>
+    ) : (
+      <span key={i}>{part}</span>
+    ),
+  );
+}

--- a/packages/cre8-studio/src/components/shell/app-shell.tsx
+++ b/packages/cre8-studio/src/components/shell/app-shell.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { NAV, activeRoute } from "@/lib/nav";
+import ThemeToggle from "./theme-toggle";
+import { ToastViewport } from "./toast";
+
+// Persistent chrome for every studio route: a slim icon rail + a thin top bar.
+// Pages render only their content; titles come from the route registry.
+export default function AppShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname() ?? "/";
+  const active = activeRoute(pathname);
+
+  return (
+    <div className="shell">
+      <nav className="rail" aria-label="Primary">
+        <Link href="/" className="rail-brand" aria-label="cre8 studio home">
+          <span className="rail-brand-mark">c8</span>
+        </Link>
+        <div className="rail-nav">
+          {NAV.map((r) => {
+            const isActive = r.href === active.href;
+            return (
+              <Link
+                key={r.href}
+                href={r.href}
+                className={`rail-item${isActive ? " active" : ""}`}
+                aria-label={r.label}
+                aria-current={isActive ? "page" : undefined}
+                data-tip={r.label}
+              >
+                {r.icon}
+              </Link>
+            );
+          })}
+        </div>
+        <div className="rail-foot">
+          <ThemeToggle />
+        </div>
+      </nav>
+
+      <div className="shell-main">
+        <header className="topbar">
+          <div className="topbar-titles">
+            <h1 className="topbar-title">{active.title}</h1>
+            <span className="topbar-subtitle">{active.subtitle}</span>
+          </div>
+          <div className="topbar-actions">
+            <a
+              className="topbar-link"
+              href="https://github.com/tmorrowdev/Cre8-Components"
+              target="_blank"
+              rel="noreferrer"
+            >
+              GitHub
+            </a>
+          </div>
+        </header>
+        <div className="shell-content">{children}</div>
+      </div>
+
+      <ToastViewport />
+    </div>
+  );
+}

--- a/packages/cre8-studio/src/components/shell/modal.tsx
+++ b/packages/cre8-studio/src/components/shell/modal.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+// Accessible modal dialog: focus-traps lightly, closes on Escape / backdrop,
+// restores focus on unmount. Used for flows that previously relied on window.prompt.
+export default function Modal({
+  open,
+  title,
+  description,
+  onClose,
+  children,
+  footer,
+}: {
+  open: boolean;
+  title: string;
+  description?: string;
+  onClose: () => void;
+  children?: React.ReactNode;
+  footer?: React.ReactNode;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const restoreTo = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    restoreTo.current = document.activeElement as HTMLElement | null;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    // focus the first focusable element in the dialog
+    const first = ref.current?.querySelector<HTMLElement>(
+      "input, textarea, select, button, [tabindex]",
+    );
+    first?.focus();
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      restoreTo.current?.focus?.();
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="modal-backdrop" onMouseDown={onClose}>
+      <div
+        className="modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        ref={ref}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <div className="modal-head">
+          <h2 className="modal-title">{title}</h2>
+          {description && <p className="modal-desc">{description}</p>}
+        </div>
+        {children && <div className="modal-body">{children}</div>}
+        {footer && <div className="modal-foot">{footer}</div>}
+      </div>
+    </div>
+  );
+}

--- a/packages/cre8-studio/src/components/shell/theme-toggle.tsx
+++ b/packages/cre8-studio/src/components/shell/theme-toggle.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const KEY = "cre8-ui-theme";
+type Mode = "dark" | "light";
+
+function current(): Mode {
+  if (typeof document === "undefined") return "dark";
+  return document.documentElement.dataset.theme === "light" ? "light" : "dark";
+}
+
+// Toggles the app chrome between dark and light. The actual attribute is set
+// pre-paint by the inline script in layout.tsx (no FOUC); this just flips it.
+export default function ThemeToggle() {
+  const [mode, setMode] = useState<Mode>("dark");
+
+  useEffect(() => setMode(current()), []);
+
+  const toggle = () => {
+    const next: Mode = current() === "dark" ? "light" : "dark";
+    document.documentElement.dataset.theme = next;
+    try {
+      localStorage.setItem(KEY, next);
+    } catch {
+      /* ignore */
+    }
+    setMode(next);
+  };
+
+  return (
+    <button
+      type="button"
+      className="theme-toggle"
+      onClick={toggle}
+      title={mode === "dark" ? "Switch to light" : "Switch to dark"}
+      aria-label="Toggle color theme"
+    >
+      {mode === "dark" ? (
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path
+            d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"
+            stroke="currentColor"
+            strokeWidth="1.7"
+            strokeLinejoin="round"
+          />
+        </svg>
+      ) : (
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <circle cx="12" cy="12" r="4.2" stroke="currentColor" strokeWidth="1.7" />
+          <path
+            d="M12 2v2.5M12 19.5V22M2 12h2.5M19.5 12H22M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M19.1 4.9l-1.8 1.8M6.7 17.3l-1.8 1.8"
+            stroke="currentColor"
+            strokeWidth="1.7"
+            strokeLinecap="round"
+          />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/packages/cre8-studio/src/components/shell/toast.tsx
+++ b/packages/cre8-studio/src/components/shell/toast.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export type ToastKind = "success" | "error" | "info";
+export interface Toast {
+  id: number;
+  kind: ToastKind;
+  message: string;
+}
+
+// Tiny event-based toast bus — no context/provider needed; any module can call
+// toast(). The viewport (mounted once in AppShell) renders the queue.
+type Listener = (t: Toast) => void;
+const listeners = new Set<Listener>();
+let seq = 1;
+
+export function toast(message: string, kind: ToastKind = "info") {
+  const t: Toast = { id: seq++, kind, message };
+  listeners.forEach((l) => l(t));
+}
+toast.success = (m: string) => toast(m, "success");
+toast.error = (m: string) => toast(m, "error");
+
+const ICONS: Record<ToastKind, string> = {
+  success: "✓",
+  error: "!",
+  info: "i",
+};
+
+export function ToastViewport() {
+  const [items, setItems] = useState<Toast[]>([]);
+
+  useEffect(() => {
+    const onToast: Listener = (t) => {
+      setItems((prev) => [...prev, t]);
+      const ttl = t.kind === "error" ? 6000 : 3500;
+      window.setTimeout(() => {
+        setItems((prev) => prev.filter((x) => x.id !== t.id));
+      }, ttl);
+    };
+    listeners.add(onToast);
+    return () => {
+      listeners.delete(onToast);
+    };
+  }, []);
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="toast-viewport" role="status" aria-live="polite">
+      {items.map((t) => (
+        <div key={t.id} className={`toast toast--${t.kind}`}>
+          <span className={`toast-icon toast-icon--${t.kind}`}>{ICONS[t.kind]}</span>
+          <span className="toast-msg">{t.message}</span>
+          <button
+            type="button"
+            className="toast-close"
+            aria-label="Dismiss"
+            onClick={() => setItems((prev) => prev.filter((x) => x.id !== t.id))}
+          >
+            ✕
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/cre8-studio/src/lib/a2ui-demo/component-catalog.ts
+++ b/packages/cre8-studio/src/lib/a2ui-demo/component-catalog.ts
@@ -1,0 +1,51 @@
+import catalog from "@tmorrow/cre8-wc/a2ui/catalog.json" with { type: "json" };
+import type { CatalogComponent } from "./types";
+
+type RawDef = {
+  title?: string;
+  description?: string;
+  "x-category"?: string;
+  properties?: {
+    props?: { properties?: Record<string, unknown> };
+    slots?: { properties?: Record<string, unknown> };
+    events?: { properties?: Record<string, unknown> };
+  };
+  "x-events"?: Record<string, unknown>;
+};
+
+type RawCatalog = { $defs?: { components?: Record<string, RawDef> } };
+
+let cached: CatalogComponent[] | null = null;
+
+// Flatten catalog.json into a list of @-mentionable components. Memoised — the
+// catalog is static for the life of the process / page.
+export function getCatalogComponents(): CatalogComponent[] {
+  if (cached) return cached;
+  const comps = (catalog as RawCatalog).$defs?.components ?? {};
+  cached = Object.entries(comps).map(([name, def]) => {
+    const desc = (def.description ?? "").split("\n")[0].trim();
+    return {
+      name,
+      title: def.title ?? name,
+      description: desc,
+      category: def["x-category"] ?? "Other",
+      props: Object.keys(def.properties?.props?.properties ?? {}),
+      slots: Object.keys(def.properties?.slots?.properties ?? {}),
+      events: Object.keys(def["x-events"] ?? def.properties?.events?.properties ?? {}),
+    };
+  });
+  return cached;
+}
+
+export function findComponent(name: string): CatalogComponent | undefined {
+  return getCatalogComponents().find((c) => c.name === name);
+}
+
+// A compact, model-friendly description of a component for context injection.
+export function describeComponent(c: CatalogComponent): string {
+  const parts = [`${c.name} — ${c.description || c.title}`];
+  if (c.props.length) parts.push(`  props: ${c.props.slice(0, 12).join(", ")}`);
+  if (c.slots.length) parts.push(`  slots: ${c.slots.join(", ")}`);
+  if (c.events.length) parts.push(`  events: ${c.events.join(", ")}`);
+  return parts.join("\n");
+}

--- a/packages/cre8-studio/src/lib/a2ui-demo/component-catalog.ts
+++ b/packages/cre8-studio/src/lib/a2ui-demo/component-catalog.ts
@@ -7,6 +7,7 @@ type RawDef = {
   "x-category"?: string;
   properties?: {
     props?: { properties?: Record<string, unknown> };
+    children?: unknown;
     slots?: { properties?: Record<string, unknown> };
     events?: { properties?: Record<string, unknown> };
   };
@@ -32,6 +33,7 @@ export function getCatalogComponents(): CatalogComponent[] {
       props: Object.keys(def.properties?.props?.properties ?? {}),
       slots: Object.keys(def.properties?.slots?.properties ?? {}),
       events: Object.keys(def["x-events"] ?? def.properties?.events?.properties ?? {}),
+      acceptsChildren: !!def.properties?.children,
     };
   });
   return cached;
@@ -45,6 +47,10 @@ export function findComponent(name: string): CatalogComponent | undefined {
 export function describeComponent(c: CatalogComponent): string {
   const parts = [`${c.name} — ${c.description || c.title}`];
   if (c.props.length) parts.push(`  props: ${c.props.slice(0, 12).join(", ")}`);
+  // Make the post-refactor content rule explicit so @-mentioned components are
+  // composed correctly (children[] vs slots.default).
+  if (c.acceptsChildren) parts.push(`  content: children[]`);
+  else if (c.slots.includes("default")) parts.push(`  content: slots.default (NOT children)`);
   if (c.slots.length) parts.push(`  slots: ${c.slots.join(", ")}`);
   if (c.events.length) parts.push(`  events: ${c.events.join(", ")}`);
   return parts.join("\n");

--- a/packages/cre8-studio/src/lib/a2ui-demo/mentions.ts
+++ b/packages/cre8-studio/src/lib/a2ui-demo/mentions.ts
@@ -1,0 +1,110 @@
+import type { CatalogComponent, DataSource, Mention, Pattern } from "./types";
+import { describeComponent } from "./component-catalog";
+import { describeDataSource } from "./seed-data";
+
+// A unified, searchable @-mention item drawn from the three libraries.
+export interface MentionItem {
+  kind: Mention["kind"];
+  id: string;
+  label: string; // token text after the @ (no spaces)
+  title: string; // display name
+  detail: string; // secondary line
+}
+
+export function patternItem(p: Pattern): MentionItem {
+  return {
+    kind: "pattern",
+    id: p.id,
+    label: tokenize(p.name),
+    title: p.name,
+    detail: p.description || p.category,
+  };
+}
+
+export function componentItem(c: CatalogComponent): MentionItem {
+  return {
+    kind: "component",
+    id: c.name,
+    label: c.name,
+    title: c.name,
+    detail: c.description || c.category,
+  };
+}
+
+export function dataItem(d: DataSource): MentionItem {
+  return {
+    kind: "data",
+    id: d.id,
+    label: tokenize(d.name),
+    title: d.name,
+    detail: d.description,
+  };
+}
+
+export function tokenize(s: string): string {
+  return s.trim().replace(/\s+/g, "-");
+}
+
+// Build the context block appended to a user message so the model can act on the
+// referenced patterns / components / data sources.
+export function buildMentionContext(
+  mentions: Mention[],
+  lookup: {
+    patterns: Pattern[];
+    components: CatalogComponent[];
+    dataSources: DataSource[];
+  },
+): string {
+  if (mentions.length === 0) return "";
+  const sections: string[] = [];
+
+  const comps = mentions
+    .filter((m) => m.kind === "component")
+    .map((m) => lookup.components.find((c) => c.name === m.id))
+    .filter((c): c is CatalogComponent => !!c);
+  if (comps.length) {
+    sections.push(
+      "Referenced components (use these in render_ui):\n" +
+        comps.map(describeComponent).join("\n"),
+    );
+  }
+
+  const pats = mentions
+    .filter((m) => m.kind === "pattern")
+    .map((m) => lookup.patterns.find((p) => p.id === m.id))
+    .filter((p): p is Pattern => !!p);
+  if (pats.length) {
+    sections.push(
+      "Referenced patterns (reuse or adapt these A2UI specs):\n" +
+        pats
+          .map((p) => `Pattern "${p.name}" (${p.category}):\n${JSON.stringify(p.spec)}`)
+          .join("\n\n"),
+    );
+  }
+
+  const data = mentions
+    .filter((m) => m.kind === "data")
+    .map((m) => lookup.dataSources.find((d) => d.id === m.id))
+    .filter((d): d is DataSource => !!d);
+  if (data.length) {
+    sections.push(
+      "Referenced data sources (bind the UI to this shape; use sample rows):\n" +
+        data.map(describeDataSource).join("\n\n"),
+    );
+  }
+
+  return `\n\n---\n[Workspace context — the user @-mentioned these]\n${sections.join("\n\n")}`;
+}
+
+// Reconcile a tracked mention list against the current composer text: keep only
+// mentions whose @token still appears.
+export function reconcileMentions(text: string, mentions: Mention[]): Mention[] {
+  const seen = new Set<string>();
+  return mentions.filter((m) => {
+    const key = `${m.kind}:${m.id}`;
+    if (seen.has(key)) return false;
+    if (!text.includes(`@${m.label}`)) return false;
+    seen.add(key);
+    return true;
+  });
+}

--- a/packages/cre8-studio/src/lib/a2ui-demo/preview-spec.ts
+++ b/packages/cre8-studio/src/lib/a2ui-demo/preview-spec.ts
@@ -1,0 +1,83 @@
+import type { ComponentSpec } from "@tmorrow/cre8-wc/a2ui";
+
+// A compact showcase spec used to preview a brand theme — exercises the most
+// color-sensitive surfaces: a branded band, headings, buttons (primary +
+// secondary), a card and a notification.
+export const BRAND_PREVIEW_SPEC: ComponentSpec = {
+  component: "cre8-layout-section",
+  children: [
+    {
+      component: "cre8-band",
+      props: { variant: "branded" },
+      children: [
+        {
+          component: "cre8-hero",
+          props: { align: "center" },
+          children: [
+            {
+              component: "cre8-heading",
+              props: { type: "display-default", tagVariant: "h1" },
+              children: ["Your brand, themed"],
+            },
+            {
+              component: "cre8-text-passage",
+              props: { size: "large" },
+              children: [
+                "Every cre8 component picks up your palette through design tokens.",
+              ],
+            },
+            {
+              component: "cre8-button-group",
+              children: [
+                {
+                  component: "cre8-button",
+                  props: { text: "Primary action", variant: "primary" },
+                  events: { click: "preview-primary" },
+                },
+                {
+                  component: "cre8-button",
+                  props: { text: "Secondary", variant: "secondary" },
+                  events: { click: "preview-secondary" },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      component: "cre8-grid",
+      props: { variant: "2up" },
+      children: [
+        {
+          component: "cre8-card",
+          slots: {
+            header: [
+              {
+                component: "cre8-heading",
+                props: { type: "title-default", tagVariant: "h3" },
+                children: ["Card title"],
+              },
+            ],
+            default: [
+              {
+                component: "cre8-text-passage",
+                children: ["Cards, links and accents all derive from the same ramp."],
+              },
+              {
+                component: "cre8-link",
+                props: { href: "#" },
+                slots: { default: ["A themed link"] },
+              },
+            ],
+          },
+        },
+        {
+          component: "cre8-alert",
+          props: { status: "info", variant: "standalone", headerText: "Heads up" },
+          slots: { default: ["Alerts use the brand's informational tones."] },
+        },
+      ],
+    },
+  ],
+};

--- a/packages/cre8-studio/src/lib/a2ui-demo/preview-spec.ts
+++ b/packages/cre8-studio/src/lib/a2ui-demo/preview-spec.ts
@@ -11,35 +11,29 @@ export const BRAND_PREVIEW_SPEC: ComponentSpec = {
       props: { variant: "branded" },
       children: [
         {
-          component: "cre8-hero",
-          props: { align: "center" },
+          component: "cre8-heading",
+          props: { type: "display-default", tagVariant: "h1" },
+          children: ["Your brand, themed"],
+        },
+        {
+          component: "cre8-text-passage",
+          props: { size: "large" },
+          children: [
+            "Every cre8 component picks up your palette through design tokens.",
+          ],
+        },
+        {
+          component: "cre8-button-group",
           children: [
             {
-              component: "cre8-heading",
-              props: { type: "display-default", tagVariant: "h1" },
-              children: ["Your brand, themed"],
+              component: "cre8-button",
+              props: { text: "Primary action", variant: "primary" },
+              events: { click: "preview-primary" },
             },
             {
-              component: "cre8-text-passage",
-              props: { size: "large" },
-              children: [
-                "Every cre8 component picks up your palette through design tokens.",
-              ],
-            },
-            {
-              component: "cre8-button-group",
-              children: [
-                {
-                  component: "cre8-button",
-                  props: { text: "Primary action", variant: "primary" },
-                  events: { click: "preview-primary" },
-                },
-                {
-                  component: "cre8-button",
-                  props: { text: "Secondary", variant: "secondary" },
-                  events: { click: "preview-secondary" },
-                },
-              ],
+              component: "cre8-button",
+              props: { text: "Secondary", variant: "secondary" },
+              events: { click: "preview-secondary" },
             },
           ],
         },
@@ -73,9 +67,9 @@ export const BRAND_PREVIEW_SPEC: ComponentSpec = {
           },
         },
         {
-          component: "cre8-alert",
-          props: { status: "info", variant: "standalone", headerText: "Heads up" },
-          slots: { default: ["Alerts use the brand's informational tones."] },
+          component: "cre8-inline-alert",
+          props: { status: "info", variant: "subtle", iconTitle: "Heads up" },
+          children: ["Inline alerts use the brand's informational tones."],
         },
       ],
     },

--- a/packages/cre8-studio/src/lib/a2ui-demo/ramp.ts
+++ b/packages/cre8-studio/src/lib/a2ui-demo/ramp.ts
@@ -1,0 +1,137 @@
+// Color ramp utilities shared by the brand-extract API route and the client.
+//
+// The cre8-a2ui token set is built on a Tailwind-style "blue" ramp. To retheme
+// the whole system from a single brand color we generate a parallel ramp at the
+// same lightness positions and substitute it for the original blue ramp wherever
+// those exact hex values appear in the token CSS. This retints every surface
+// (buttons, bands, headers, links, focus rings) consistently.
+
+export type Hsl = { h: number; s: number; l: number };
+
+// Tailwind "blue" ramp — these are the literal hex values used throughout the
+// cre8-a2ui brand token CSS. Order: 50,100,200,300,400,500,600,700,800,900,950.
+export const BLUE_RAMP = [
+  "#EFF6FF",
+  "#DBEAFE",
+  "#BFDBFE",
+  "#93C5FD",
+  "#60A5FA",
+  "#3B82F6",
+  "#2563EB",
+  "#1D4ED8",
+  "#1E40AF",
+  "#1E3A8A",
+  "#172554",
+] as const;
+
+// Target lightness (%) for each ramp step. Anchored so step 500 (index 5) is the
+// brand's own lightness; the rest fan out to light tints and dark shades.
+const RAMP_LIGHTNESS = [97, 93, 86, 75, 65, 55, 47, 40, 33, 27, 18];
+
+export function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
+  let h = hex.trim().replace(/^#/, "");
+  if (h.length === 3) h = h.split("").map((c) => c + c).join("");
+  if (h.length !== 6 || /[^0-9a-fA-F]/.test(h)) return null;
+  return {
+    r: parseInt(h.slice(0, 2), 16),
+    g: parseInt(h.slice(2, 4), 16),
+    b: parseInt(h.slice(4, 6), 16),
+  };
+}
+
+export function rgbToHex(r: number, g: number, b: number): string {
+  const c = (n: number) =>
+    Math.max(0, Math.min(255, Math.round(n))).toString(16).padStart(2, "0");
+  return `#${c(r)}${c(g)}${c(b)}`.toUpperCase();
+}
+
+export function rgbToHsl(r: number, g: number, b: number): Hsl {
+  r /= 255;
+  g /= 255;
+  b /= 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+  const d = max - min;
+  if (d !== 0) {
+    s = d / (1 - Math.abs(2 * l - 1));
+    switch (max) {
+      case r:
+        h = ((g - b) / d) % 6;
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      default:
+        h = (r - g) / d + 4;
+    }
+    h *= 60;
+    if (h < 0) h += 360;
+  }
+  return { h, s: s * 100, l: l * 100 };
+}
+
+export function hslToHex(h: number, s: number, l: number): string {
+  s /= 100;
+  l /= 100;
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  if (h < 60) [r, g, b] = [c, x, 0];
+  else if (h < 120) [r, g, b] = [x, c, 0];
+  else if (h < 180) [r, g, b] = [0, c, x];
+  else if (h < 240) [r, g, b] = [0, x, c];
+  else if (h < 300) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+  return rgbToHex((r + m) * 255, (g + m) * 255, (b + m) * 255);
+}
+
+export function hexToHsl(hex: string): Hsl | null {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return null;
+  return rgbToHsl(rgb.r, rgb.g, rgb.b);
+}
+
+// Relative luminance (sRGB) — used to pick black/white content on a fill.
+export function luminance(hex: string): number {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return 0;
+  const lin = (v: number) => {
+    v /= 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * lin(rgb.r) + 0.7152 * lin(rgb.g) + 0.0722 * lin(rgb.b);
+}
+
+export function readableOn(hex: string): "#ffffff" | "#0F172A" {
+  return luminance(hex) > 0.45 ? "#0F172A" : "#ffffff";
+}
+
+// Build an 11-step ramp from a single brand color, holding its hue/saturation and
+// walking the canonical lightness positions. Saturation tapers slightly at the
+// extremes so the lightest tints don't look neon and the darkest shades stay rich.
+export function buildRamp(primary: string): string[] {
+  const hsl = hexToHsl(primary);
+  if (!hsl) return [...BLUE_RAMP];
+  const baseSat = Math.max(20, Math.min(95, hsl.s));
+  return RAMP_LIGHTNESS.map((l, i) => {
+    const dist = Math.abs(i - 5) / 5; // 0 at anchor, 1 at extremes
+    const sat = i <= 5 ? baseSat * (1 - dist * 0.2) : baseSat * (1 - dist * 0.1);
+    return hslToHex(hsl.h, sat, l);
+  });
+}
+
+// Map original blue ramp hex -> brand ramp hex (case-insensitive keys).
+export function buildSubstitution(primary: string): Record<string, string> {
+  const ramp = buildRamp(primary);
+  const map: Record<string, string> = {};
+  BLUE_RAMP.forEach((blue, i) => {
+    map[blue.toUpperCase()] = ramp[i];
+  });
+  return map;
+}

--- a/packages/cre8-studio/src/lib/a2ui-demo/seed-data.ts
+++ b/packages/cre8-studio/src/lib/a2ui-demo/seed-data.ts
@@ -1,0 +1,88 @@
+import type { DataSource } from "./types";
+
+// Prepopulated mock data sources. These are deliberately small — the schema and a
+// few sample rows are injected into the model context when @-mentioned so the
+// agent can build realistic, data-bound UI without a live backend.
+export const SEED_DATA_SOURCES: DataSource[] = [
+  {
+    id: "ds-users",
+    name: "users",
+    description: "Application user accounts with role and status.",
+    builtin: true,
+    columns: [
+      { name: "id", type: "uuid" },
+      { name: "name", type: "text" },
+      { name: "email", type: "text" },
+      { name: "role", type: "enum(admin,member,viewer)" },
+      { name: "status", type: "enum(active,invited,suspended)" },
+      { name: "created_at", type: "timestamp" },
+    ],
+    sample: [
+      { id: "u_01", name: "Avery Chen", email: "avery@acme.io", role: "admin", status: "active", created_at: "2026-01-12" },
+      { id: "u_02", name: "Jordan Patel", email: "jordan@acme.io", role: "member", status: "active", created_at: "2026-02-03" },
+      { id: "u_03", name: "Sam Rivera", email: "sam@acme.io", role: "viewer", status: "invited", created_at: "2026-03-21" },
+    ],
+  },
+  {
+    id: "ds-orders",
+    name: "orders",
+    description: "Customer orders with line totals and fulfillment state.",
+    builtin: true,
+    columns: [
+      { name: "id", type: "text" },
+      { name: "customer", type: "text" },
+      { name: "total", type: "currency" },
+      { name: "items", type: "int" },
+      { name: "status", type: "enum(paid,pending,refunded,shipped)" },
+      { name: "placed_at", type: "timestamp" },
+    ],
+    sample: [
+      { id: "#1042", customer: "Avery Chen", total: 128.0, items: 3, status: "shipped", placed_at: "2026-06-01" },
+      { id: "#1043", customer: "Jordan Patel", total: 54.5, items: 1, status: "paid", placed_at: "2026-06-02" },
+      { id: "#1044", customer: "Sam Rivera", total: 312.99, items: 7, status: "pending", placed_at: "2026-06-03" },
+    ],
+  },
+  {
+    id: "ds-products",
+    name: "products",
+    description: "Catalog of products with price, inventory and rating.",
+    builtin: true,
+    columns: [
+      { name: "sku", type: "text" },
+      { name: "title", type: "text" },
+      { name: "price", type: "currency" },
+      { name: "stock", type: "int" },
+      { name: "rating", type: "float" },
+      { name: "category", type: "text" },
+    ],
+    sample: [
+      { sku: "CR8-100", title: "Aero Standing Desk", price: 489.0, stock: 24, rating: 4.7, category: "Workspace" },
+      { sku: "CR8-220", title: "Lumen Task Lamp", price: 79.0, stock: 140, rating: 4.4, category: "Lighting" },
+      { sku: "CR8-310", title: "Pulse Wireless Keyboard", price: 119.0, stock: 0, rating: 4.8, category: "Accessories" },
+    ],
+  },
+  {
+    id: "ds-tickets",
+    name: "support_tickets",
+    description: "Support tickets with priority and assignee for dashboards.",
+    builtin: true,
+    columns: [
+      { name: "id", type: "text" },
+      { name: "subject", type: "text" },
+      { name: "priority", type: "enum(low,medium,high,urgent)" },
+      { name: "assignee", type: "text" },
+      { name: "status", type: "enum(open,pending,resolved)" },
+    ],
+    sample: [
+      { id: "T-501", subject: "Login link expired", priority: "high", assignee: "Avery Chen", status: "open" },
+      { id: "T-502", subject: "Invoice PDF missing", priority: "medium", assignee: "Jordan Patel", status: "pending" },
+      { id: "T-503", subject: "Feature request: dark mode", priority: "low", assignee: "Sam Rivera", status: "open" },
+    ],
+  },
+];
+
+export function describeDataSource(ds: DataSource): string {
+  const cols = ds.columns.map((c) => `${c.name}:${c.type}`).join(", ");
+  const rows = JSON.stringify(ds.sample, null, 0);
+  return `table "${ds.name}" — ${ds.description}\n  columns: ${cols}\n  sample rows: ${rows}`;
+}

--- a/packages/cre8-studio/src/lib/a2ui-demo/store.ts
+++ b/packages/cre8-studio/src/lib/a2ui-demo/store.ts
@@ -1,0 +1,120 @@
+"use client";
+
+import type { BrandTheme, DataSource, Pattern } from "./types";
+import { SEED_DATA_SOURCES } from "./seed-data";
+
+// Demo persistence layer. Everything lives in localStorage so the demo is fully
+// client-side and survives reloads within a browser (the remote container is
+// ephemeral, so server persistence would be lost anyway). Builtin patterns are
+// fetched once from /api/a2ui-patterns and cached.
+
+const K_PATTERNS = "cre8-a2ui:patterns";
+const K_DATA = "cre8-a2ui:data-sources";
+const K_THEME = "cre8-a2ui:theme";
+
+function read<T>(key: string, fallback: T): T {
+  if (typeof window === "undefined") return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function write<T>(key: string, value: T): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+    window.dispatchEvent(new CustomEvent("cre8-a2ui:store", { detail: { key } }));
+  } catch {
+    /* quota / private mode — ignore for demo */
+  }
+}
+
+// ----- Patterns -------------------------------------------------------------
+
+let builtinPatterns: Pattern[] | null = null;
+
+export async function loadBuiltinPatterns(): Promise<Pattern[]> {
+  if (builtinPatterns) return builtinPatterns;
+  try {
+    const res = await fetch("/api/a2ui-patterns");
+    const json = (await res.json()) as { patterns: Pattern[] };
+    builtinPatterns = json.patterns ?? [];
+  } catch {
+    builtinPatterns = [];
+  }
+  return builtinPatterns;
+}
+
+export function getUserPatterns(): Pattern[] {
+  return read<Pattern[]>(K_PATTERNS, []);
+}
+
+// Builtins first, then user-saved (newest last). Builtins are passed in so the
+// caller controls when the async fetch has resolved.
+export function mergePatterns(builtins: Pattern[]): Pattern[] {
+  return [...builtins, ...getUserPatterns()];
+}
+
+export function savePattern(p: Omit<Pattern, "id" | "builtin">): Pattern {
+  const pattern: Pattern = {
+    ...p,
+    id: `user:${slug(p.name)}:${Date.now().toString(36)}`,
+  };
+  const next = [...getUserPatterns(), pattern];
+  write(K_PATTERNS, next);
+  return pattern;
+}
+
+export function deletePattern(id: string): void {
+  write(K_PATTERNS, getUserPatterns().filter((p) => p.id !== id));
+}
+
+// ----- Data sources ---------------------------------------------------------
+
+export function getDataSources(): DataSource[] {
+  const user = read<DataSource[]>(K_DATA, []);
+  return [...SEED_DATA_SOURCES, ...user];
+}
+
+export function saveDataSource(ds: Omit<DataSource, "id" | "builtin">): DataSource {
+  const source: DataSource = { ...ds, id: `ds-user:${slug(ds.name)}:${Date.now().toString(36)}` };
+  const user = read<DataSource[]>(K_DATA, []);
+  write(K_DATA, [...user, source]);
+  return source;
+}
+
+export function deleteDataSource(id: string): void {
+  const user = read<DataSource[]>(K_DATA, []);
+  write(K_DATA, user.filter((d) => d.id !== id));
+}
+
+// ----- Brand theme ----------------------------------------------------------
+
+export function getTheme(): BrandTheme | null {
+  return read<BrandTheme | null>(K_THEME, null);
+}
+
+export function setTheme(theme: BrandTheme | null): void {
+  write(K_THEME, theme);
+}
+
+// ----- helpers --------------------------------------------------------------
+
+export function slug(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 40) || "item";
+}
+
+// Subscribe to cross-component store changes (and other tabs).
+export function onStoreChange(cb: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const handler = () => cb();
+  window.addEventListener("cre8-a2ui:store", handler);
+  window.addEventListener("storage", handler);
+  return () => {
+    window.removeEventListener("cre8-a2ui:store", handler);
+    window.removeEventListener("storage", handler);
+  };
+}

--- a/packages/cre8-studio/src/lib/a2ui-demo/theme.ts
+++ b/packages/cre8-studio/src/lib/a2ui-demo/theme.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import type { BrandTheme } from "./types";
+
+const STYLE_ID = "cre8-a2ui-brand-theme";
+
+// Inject (or update) the brand theme override stylesheet at document level so the
+// custom properties cascade into every cre8-wc component's shadow DOM. Passing
+// null removes the override and restores the default cre8-a2ui palette.
+export function applyTheme(theme: BrandTheme | null): void {
+  if (typeof document === "undefined") return;
+  let el = document.getElementById(STYLE_ID) as HTMLStyleElement | null;
+  if (!theme) {
+    el?.remove();
+    return;
+  }
+  if (!el) {
+    el = document.createElement("style");
+    el.id = STYLE_ID;
+    document.head.appendChild(el);
+  }
+  const fontRule = theme.fontFamily
+    ? `:root{--cre8-typography-body-default-font-family:${cssFont(theme.fontFamily)};` +
+      `--cre8-typography-heading-default-font-family:${cssFont(theme.fontFamily)};}`
+    : "";
+  el.textContent = `${theme.css}\n${fontRule}`;
+}
+
+// A small inline preview stylesheet scoped to a container, for the extractor's
+// before/after comparison without mutating the whole document.
+export function scopedThemeCss(theme: BrandTheme, selector: string): string {
+  return theme.css.replace(/:root\b/g, selector);
+}
+
+function cssFont(f: string): string {
+  // Ensure a sane fallback chain.
+  const trimmed = f.trim();
+  if (/sans-serif|serif|monospace|system-ui/.test(trimmed)) return trimmed;
+  return `${trimmed}, system-ui, sans-serif`;
+}

--- a/packages/cre8-studio/src/lib/a2ui-demo/types.ts
+++ b/packages/cre8-studio/src/lib/a2ui-demo/types.ts
@@ -1,0 +1,57 @@
+import type { ComponentSpec } from "@tmorrow/cre8-wc/a2ui";
+
+// A reusable A2UI pattern — anything from a single component up to a full UI page.
+// Seeded patterns ship with the app; user patterns are saved from the workspace.
+export interface Pattern {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  spec: ComponentSpec;
+  builtin?: boolean;
+}
+
+// A cre8-wc component as an @-mentionable item.
+export interface CatalogComponent {
+  name: string; // e.g. "cre8-button"
+  title: string;
+  description: string;
+  category: string;
+  props: string[];
+  slots: string[];
+  events: string[];
+}
+
+// A data source the agent can build UI against. Seeded with mock datasets; the
+// schema + sample rows are injected into the model context when @-mentioned.
+export interface DataSource {
+  id: string;
+  name: string;
+  description: string;
+  columns: { name: string; type: string }[];
+  sample: Record<string, unknown>[];
+  builtin?: boolean;
+}
+
+// A brand theme produced by the extractor and applied across the workspace.
+export interface BrandTheme {
+  name: string;
+  primary: string; // hex
+  accent?: string; // hex
+  fontFamily?: string;
+  source?: string; // url it was extracted from
+  ramp: string[];
+  // CSS override block ( :root { ... } ) substituting the brand ramp for the
+  // default cre8-a2ui blue ramp across all tokens.
+  css: string;
+  createdAt: number;
+}
+
+// The three kinds of @-mention available in the workspace composer.
+export type MentionKind = "pattern" | "component" | "data";
+
+export interface Mention {
+  kind: MentionKind;
+  id: string; // pattern id | component name | data source id
+  label: string; // shown in the chip / inline token
+}

--- a/packages/cre8-studio/src/lib/a2ui-demo/types.ts
+++ b/packages/cre8-studio/src/lib/a2ui-demo/types.ts
@@ -20,6 +20,9 @@ export interface CatalogComponent {
   props: string[];
   slots: string[];
   events: string[];
+  // Post-refactor content rule: true → body goes in top-level `children`;
+  // false → body goes in `slots.default` (top-level children is rejected).
+  acceptsChildren: boolean;
 }
 
 // A data source the agent can build UI against. Seeded with mock datasets; the

--- a/packages/cre8-studio/src/lib/catalog-index.ts
+++ b/packages/cre8-studio/src/lib/catalog-index.ts
@@ -10,6 +10,7 @@ type CatalogJson = {
           props?: {
             properties?: Record<string, { description?: string; enum?: unknown[]; const?: unknown; type?: unknown }>;
           };
+          children?: unknown;
           slots?: { properties?: Record<string, { description?: string }> };
           events?: { properties?: Record<string, { description?: string }> };
         };
@@ -37,10 +38,20 @@ export function buildCatalogSummary(): string {
       .join(", ");
     const slots = Object.keys(def.properties?.slots?.properties ?? {});
     const events = Object.keys(def.properties?.events?.properties ?? {});
+    // Post-refactor the default content slot is explicit: a component either has
+    // a top-level `children` array OR a named `slots.default` — never both, and
+    // the two are NOT interchangeable. Spell this out so the model never puts
+    // body content in `children` for a slot-based component.
+    const acceptsChildren = !!def.properties?.children;
 
     let line = `- ${name}`;
     if (desc) line += ` — ${desc}`;
     if (propSummary) line += `\n    props: ${propSummary}`;
+    if (acceptsChildren) {
+      line += `\n    content: children[]`;
+    } else if (slots.includes("default")) {
+      line += `\n    content: slots.default  (NOT children)`;
+    }
     if (slots.length) line += `\n    slots: ${slots.join(", ")}`;
     if (events.length) line += `\n    events: ${events.join(", ")}`;
     lines.push(line);

--- a/packages/cre8-studio/src/lib/nav.tsx
+++ b/packages/cre8-studio/src/lib/nav.tsx
@@ -1,0 +1,113 @@
+import type { ReactNode } from "react";
+
+// Route registry that drives the shell's nav rail and top bar. Keeping titles
+// here lets every page drop its ad-hoc <header> in favour of one consistent bar.
+export interface NavRoute {
+  href: string;
+  label: string; // rail tooltip + a11y label
+  title: string; // top bar title
+  subtitle: string; // top bar subtitle
+  icon: ReactNode;
+}
+
+const I = (d: ReactNode) => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    {d}
+  </svg>
+);
+const stroke = {
+  stroke: "currentColor",
+  strokeWidth: 1.7,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+  fill: "none",
+};
+
+export const NAV: NavRoute[] = [
+  {
+    href: "/",
+    label: "Studio",
+    title: "cre8 studio",
+    subtitle: "Agent-composed UI · streaming chat",
+    icon: I(
+      <>
+        <path {...stroke} d="M4 7h16M4 12h16M4 17h10" />
+      </>,
+    ),
+  },
+  {
+    href: "/a2ui",
+    label: "A2UI",
+    title: "cre8 A2UI",
+    subtitle: "Connect a brand · build apps with patterns, components & data",
+    icon: I(
+      <>
+        <rect {...stroke} x="3" y="3" width="7" height="7" rx="1.5" />
+        <rect {...stroke} x="14" y="3" width="7" height="7" rx="1.5" />
+        <rect {...stroke} x="3" y="14" width="7" height="7" rx="1.5" />
+        <rect {...stroke} x="14" y="14" width="7" height="7" rx="1.5" />
+      </>,
+    ),
+  },
+  {
+    href: "/build",
+    label: "App Builder",
+    title: "cre8 apps",
+    subtitle: "Describe an app → live canvas + schema",
+    icon: I(
+      <>
+        <path {...stroke} d="M12 3l8 4.5v9L12 21l-8-4.5v-9L12 3z" />
+        <path {...stroke} d="M12 12l8-4.5M12 12v9M12 12L4 7.5" />
+      </>,
+    ),
+  },
+  {
+    href: "/stack",
+    label: "Stack",
+    title: "cre8 stack",
+    subtitle: "Chat · build · preview — full stack in one view",
+    icon: I(
+      <>
+        <path {...stroke} d="M12 3l9 5-9 5-9-5 9-5z" />
+        <path {...stroke} d="M3 12l9 5 9-5M3 16l9 5 9-5" />
+      </>,
+    ),
+  },
+  {
+    href: "/data",
+    label: "Data Agent",
+    title: "cre8 data agent",
+    subtitle: "Claude Agent SDK · data → cre8 a2ui",
+    icon: I(
+      <>
+        <ellipse {...stroke} cx="12" cy="6" rx="7" ry="3" />
+        <path {...stroke} d="M5 6v12c0 1.7 3.1 3 7 3s7-1.3 7-3V6M5 12c0 1.7 3.1 3 7 3s7-1.3 7-3" />
+      </>,
+    ),
+  },
+  {
+    href: "/explore",
+    label: "Explore",
+    title: "cre8 explore",
+    subtitle: "Agent-driven data exploration · mcp-ui",
+    icon: I(
+      <>
+        <circle {...stroke} cx="11" cy="11" r="7" />
+        <path {...stroke} d="M21 21l-4.3-4.3" />
+      </>,
+    ),
+  },
+];
+
+// Longest-prefix match so nested routes (e.g. /a2ui/workspace) resolve to /a2ui.
+export function activeRoute(pathname: string): NavRoute {
+  let best = NAV[0];
+  for (const r of NAV) {
+    if (r.href === "/") continue;
+    if ((pathname === r.href || pathname.startsWith(r.href + "/") || pathname === r.href) && r.href.length > best.href.length) {
+      best = r;
+    }
+  }
+  if (pathname === "/") return NAV[0];
+  return best;
+}

--- a/packages/cre8-studio/src/lib/server/brand-theme.ts
+++ b/packages/cre8-studio/src/lib/server/brand-theme.ts
@@ -1,0 +1,148 @@
+import { readFile } from "fs/promises";
+import path from "path";
+import { BLUE_RAMP, buildRamp, buildSubstitution } from "../a2ui-demo/ramp";
+
+// Server helpers for the brand-extract route: build the cre8 token override CSS
+// from a brand color, and best-effort extract a brand color + font from a URL.
+
+const BRAND_CSS = "../cre8-wc/design-tokens/brands/cre8-a2ui/css/tokens_brand.css";
+
+let cachedTokenLines: { prop: string; value: string }[] | null = null;
+
+// Parse the brand token CSS once into (custom-property, value) pairs.
+async function tokenLines(): Promise<{ prop: string; value: string }[]> {
+  if (cachedTokenLines) return cachedTokenLines;
+  const file = path.resolve(process.cwd(), BRAND_CSS);
+  const css = await readFile(file, "utf8");
+  const lines: { prop: string; value: string }[] = [];
+  const re = /(--cre8-[a-z0-9-]+)\s*:\s*([^;]+);/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(css)) !== null) {
+    lines.push({ prop: m[1], value: m[2].trim() });
+  }
+  cachedTokenLines = lines;
+  return lines;
+}
+
+// Produce a :root override block that substitutes the brand ramp for every token
+// whose value references a blue-ramp hex. Returns the CSS string.
+export async function buildThemeCss(primary: string): Promise<string> {
+  const sub = buildSubstitution(primary);
+  const blueSet = new Set(BLUE_RAMP.map((h) => h.toUpperCase()));
+  const lines = await tokenLines();
+  const out: string[] = [];
+  for (const { prop, value } of lines) {
+    // Substitute any blue-ramp hex appearing in the value (covers solid fills,
+    // gradients and multi-stop values).
+    let replaced = value;
+    let touched = false;
+    replaced = replaced.replace(/#[0-9a-fA-F]{6}/g, (hex) => {
+      const up = hex.toUpperCase();
+      if (blueSet.has(up)) {
+        touched = true;
+        return sub[up];
+      }
+      return hex;
+    });
+    if (touched) out.push(`  ${prop}: ${replaced};`);
+  }
+  return `:root {\n${out.join("\n")}\n}`;
+}
+
+// ---- URL extraction --------------------------------------------------------
+
+export interface ExtractResult {
+  primary: string;
+  fontFamily?: string;
+  candidates: string[];
+}
+
+const NEUTRALS = (hex: string): boolean => {
+  const h = hex.replace("#", "");
+  if (h.length !== 6) return true;
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const sat = max === 0 ? 0 : (max - min) / max;
+  const lum = (max + min) / 2 / 255;
+  // Reject near-grayscale, near-white and near-black.
+  return sat < 0.18 || lum > 0.93 || lum < 0.07;
+};
+
+export async function extractFromUrl(rawUrl: string): Promise<ExtractResult> {
+  const url = normalizeUrl(rawUrl);
+  const res = await fetch(url, {
+    headers: { "User-Agent": "Mozilla/5.0 (cre8-a2ui brand extractor)" },
+    redirect: "follow",
+  });
+  if (!res.ok) throw new Error(`Fetch failed: HTTP ${res.status}`);
+  const html = await res.text();
+
+  // 1. Explicit signals first: <meta name="theme-color"> and brand-ish CSS vars.
+  const themeColor = matchFirst(html, /<meta[^>]+name=["']theme-color["'][^>]+content=["']([^"']+)["']/i);
+  const explicit = normalizeColor(themeColor);
+
+  // 2. Collect all hex colors and a few rgb()s, weight by frequency.
+  const counts = new Map<string, number>();
+  for (const m of html.matchAll(/#[0-9a-fA-F]{6}\b/g)) {
+    const hex = m[0].toUpperCase();
+    if (!NEUTRALS(hex)) counts.set(hex, (counts.get(hex) ?? 0) + 1);
+  }
+  for (const m of html.matchAll(/rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)/gi)) {
+    const hex = rgbStrToHex(m[1], m[2], m[3]);
+    if (hex && !NEUTRALS(hex)) counts.set(hex, (counts.get(hex) ?? 0) + 1);
+  }
+  const ranked = [...counts.entries()].sort((a, b) => b[1] - a[1]).map(([h]) => h);
+
+  const primary = explicit ?? ranked[0] ?? "#3B82F6";
+  const fontFamily = extractFont(html);
+
+  return { primary, fontFamily, candidates: ranked.slice(0, 8) };
+}
+
+function extractFont(html: string): string | undefined {
+  // Prefer an explicit body/font-family declaration; fall back to a Google Fonts
+  // family reference in a <link>.
+  const decl = matchFirst(html, /font-family\s*:\s*([^;}"']+)/i);
+  if (decl) {
+    const first = decl.split(",")[0].replace(/['"]/g, "").trim();
+    if (first && !/inherit|var\(|initial/i.test(first)) return first;
+  }
+  const gf = matchFirst(html, /fonts\.googleapis\.com\/css2?\?family=([^:&"']+)/i);
+  if (gf) return decodeURIComponent(gf).replace(/\+/g, " ");
+  return undefined;
+}
+
+function matchFirst(s: string, re: RegExp): string | undefined {
+  const m = s.match(re);
+  return m ? m[1] : undefined;
+}
+
+function rgbStrToHex(r: string, g: string, b: string): string | null {
+  const n = [r, g, b].map((x) => Math.max(0, Math.min(255, parseInt(x, 10))));
+  if (n.some((x) => Number.isNaN(x))) return null;
+  return `#${n.map((x) => x.toString(16).padStart(2, "0")).join("")}`.toUpperCase();
+}
+
+function normalizeColor(c?: string): string | undefined {
+  if (!c) return undefined;
+  const t = c.trim();
+  if (/^#[0-9a-fA-F]{6}$/.test(t)) return t.toUpperCase();
+  if (/^#[0-9a-fA-F]{3}$/.test(t)) {
+    const h = t.slice(1);
+    return `#${h.split("").map((x) => x + x).join("")}`.toUpperCase();
+  }
+  const rgb = t.match(/rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)/i);
+  if (rgb) return rgbStrToHex(rgb[1], rgb[2], rgb[3]) ?? undefined;
+  return undefined;
+}
+
+function normalizeUrl(u: string): string {
+  const t = u.trim();
+  if (/^https?:\/\//i.test(t)) return t;
+  return `https://${t}`;
+}
+
+export { buildRamp };

--- a/packages/cre8-studio/src/lib/server/cre8-mcp.ts
+++ b/packages/cre8-studio/src/lib/server/cre8-mcp.ts
@@ -1,0 +1,94 @@
+import {
+  registerCatalog,
+  validateSpec,
+  type ComponentSpec,
+  type RegisteredCatalog,
+} from "@tmorrow/cre8-wc/a2ui";
+import { catalog as catalogJson } from "@/lib/catalog-index";
+
+// Validation client for the canonical cre8-mcp service.
+//
+// The cre8-mcp HTTP API (packages/cre8-mcp `start:api`, default :3001) owns the
+// authoritative A2UI validator via `POST /a2ui/validate`. Routing render_ui
+// validation through it keeps the studio in lock-step with the published catalog
+// rules instead of relying on a process-local copy that can drift.
+//
+// We stay resilient: if the service is unreachable we fall back to the in-process
+// validator (same `validateSpec` + package catalog the MCP uses), so the app keeps
+// working in dev/CI where the API isn't running. Set CRE8_MCP_VALIDATE=0 to force
+// local-only validation.
+
+const MCP_URL = (process.env.CRE8_MCP_URL ?? "http://localhost:3001").replace(/\/$/, "");
+const MCP_ENABLED = process.env.CRE8_MCP_VALIDATE !== "0";
+const TIMEOUT_MS = Number(process.env.CRE8_MCP_TIMEOUT_MS ?? 2000);
+
+export type ValidationResult = { ok: true } | { ok: false; error: string };
+export type ValidationOutcome = { result: ValidationResult; source: "mcp" | "local" };
+
+let registered: RegisteredCatalog | null = null;
+function localCatalog(): RegisteredCatalog {
+  if (!registered) {
+    registered = registerCatalog(
+      catalogJson as unknown as Parameters<typeof registerCatalog>[0],
+    );
+  }
+  return registered;
+}
+
+// Light circuit breaker: once the MCP looks down, stop probing it for a while so
+// every render_ui call doesn't eat the connect timeout.
+let mcpDownUntil = 0;
+const COOLDOWN_MS = 30_000;
+
+function nowMs(): number {
+  return typeof performance !== "undefined" ? performance.now() : 0;
+}
+
+// Returns a result from the MCP, or null if the service can't be reached / gave an
+// unusable response (caller falls back to local).
+async function validateViaMcp(spec: unknown): Promise<ValidationResult | null> {
+  const t = nowMs();
+  if (t < mcpDownUntil) return null;
+  try {
+    const res = await fetch(`${MCP_URL}/a2ui/validate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ spec }),
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    // 400 = bad request envelope (missing spec / bad JSON) — not a spec verdict.
+    if (res.status === 400) return null;
+    if (!res.ok) {
+      mcpDownUntil = nowMs() + COOLDOWN_MS;
+      return null;
+    }
+    const json = (await res.json()) as { ok?: unknown; error?: unknown };
+    if (json.ok === true) return { ok: true };
+    if (json.ok === false) {
+      return { ok: false, error: typeof json.error === "string" ? json.error : "Invalid spec" };
+    }
+    return null;
+  } catch {
+    mcpDownUntil = nowMs() + COOLDOWN_MS;
+    return null;
+  }
+}
+
+function validateLocally(spec: ComponentSpec): ValidationResult {
+  try {
+    validateSpec(spec, localCatalog());
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// Validate a render_ui spec, preferring the canonical MCP and falling back to the
+// in-process validator. Reports which source produced the verdict.
+export async function validateA2uiSpec(spec: ComponentSpec): Promise<ValidationOutcome> {
+  if (MCP_ENABLED) {
+    const viaMcp = await validateViaMcp(spec);
+    if (viaMcp) return { result: viaMcp, source: "mcp" };
+  }
+  return { result: validateLocally(spec), source: "local" };
+}

--- a/packages/cre8-studio/src/lib/system-prompt.ts
+++ b/packages/cre8-studio/src/lib/system-prompt.ts
@@ -13,10 +13,22 @@ The spec shape is:
 {
   "component": "cre8-X",
   "props": { ... },
-  "children": [...],              // default slot content (components or strings)
-  "slots": { "header": [...] },   // named slots
-  "events": { "click": "handler-name" }  // event handlers
+  "children": [...],              // ONLY for components whose catalog entry says "content: children[]"
+  "slots": { "default": [...], "header": [...] },  // named slots (incl. "default")
+  "events": { "click": "handler-name" }  // event handlers (string or { "handler": "name" })
 }
+
+IMPORTANT — content placement (this changed in catalog 2.0.x):
+- Each component below is annotated with how it takes body content:
+  - "content: children[]" → put content in the top-level \`children\` array.
+  - "content: slots.default (NOT children)" → put content in \`slots.default\`; a
+    top-level \`children\` array will FAIL validation for these components.
+- Components annotated only with named slots (e.g. cre8-button before/after,
+  form fields' fieldNote) take content in those slots, not \`children\`.
+- Examples:
+  - cre8-card: { "component": "cre8-card", "slots": { "default": [...], "header": [...] } }  ✅
+  - cre8-card with "children": [...]  ❌ (rejected — card uses slots.default)
+  - cre8-band: { "component": "cre8-band", "children": [...] }  ✅ (band takes children[])
 
 After you call \`render_ui\`, the user interacts with the rendered UI, and you will receive a tool_result back containing their action as JSON:
 { "event": "click", "handler": "<your-handler-name>", "component": "cre8-button", "detail": <optional> }
@@ -31,7 +43,12 @@ ${summary}
 
 # Rules
 - Only emit components from the catalog above.
-- Use slots when available (header, footer, default). String children belong in default.
+- Place body content per each component's "content:" annotation — use \`slots.default\`
+  for components marked "content: slots.default", and \`children\` only for those
+  marked "content: children[]". Never use \`children\` on a slot-based component.
+- Common slot-based (NOT children) components: cre8-card, cre8-alert, cre8-modal,
+  cre8-section, cre8-header, cre8-footer, cre8-tabs, cre8-link, cre8-text-link,
+  cre8-table-row, cre8-accordion-item.
 - For layouts prefer: cre8-layout-section, cre8-grid (variant 2up/3up/4up), cre8-band, cre8-card.
 - For text prefer cre8-heading + cre8-text-passage.
 - Include event handlers on buttons so user interactions come back to you.

--- a/packages/cre8-studio/vercel.json
+++ b/packages/cre8-studio/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "node scripts/prepare-cre8wc.mjs && next build",
+  "installCommand": "pnpm install --no-frozen-lockfile"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,11 @@ overrides:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      concurrently:
+        specifier: ^9.1.2
+        version: 9.2.3
 
   packages/cre8-mcp:
     dependencies:
@@ -4387,7 +4391,7 @@ packages:
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@babel/runtime': 7.29.2
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
@@ -6203,6 +6207,19 @@ packages:
   /component-emitter@2.0.0:
     resolution: {integrity: sha512-4m5s3Me2xxlVKG9PkZpQqHQR7bgpnN7joDMJ4yvVkVXngjoITG76IaZmzmywSeRTeTpc6N6r3H3+KyUurV8OYw==}
     engines: {node: '>=18'}
+    dev: true
+
+  /concurrently@9.2.3:
+    resolution: {integrity: sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.4
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
     dev: true
 
   /content-disposition@1.1.0:
@@ -10719,6 +10736,11 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  /shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
   /side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
@@ -11326,6 +11348,11 @@ packages:
       tslib: '2'
     dependencies:
       tslib: 2.8.1
+    dev: true
+
+  /tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
     dev: true
 
   /trim-lines@3.0.1:


### PR DESCRIPTION
## Description

Introduces a complete A2UI demo experience to cre8 studio, enabling users to connect a brand, build agent-composed UI apps with reusable patterns, components, and data sources. This includes:

- **Brand Extractor** (`/a2ui/brand`): Extract brand colors from a URL or manually pick a primary color, which automatically rethemes the entire cre8-wc component system via CSS custom property substitution
- **A2UI Workspace** (`/a2ui/workspace`): Full-featured chat interface where an agent assembles real cre8-wc UIs from @-mentionable patterns, components, and data sources
- **Design System Overhaul**: Replaced legacy cre8-a2ui tokens with a refined dark-first design system (`--ui-*` scale) featuring surfaces, text, borders, accents, feedback states, and category colors
- **Persistent Shell**: New `AppShell` component provides consistent navigation rail and top bar across all studio routes, with theme toggle and route registry
- **Supporting Infrastructure**: Toast notifications, accessible modals, color ramp utilities, localStorage-backed pattern/data persistence, and API routes for brand extraction and pattern seeding

## Scope

- [x] **New feature** - Adds A2UI demo workspace and brand theming capabilities

## Quality Checks

- [x] Documentation - Inline CSS comments for design tokens, JSDoc for utility functions
- [x] Did you use CSS Logical Properties for your CSS? - N/A (design tokens use standard properties)
- [x] I've performed a self-review of my code
- [x] My code passes linting and code quality checks
- [x] My code builds without generating new errors/warnings

## Test Plan

- Verify brand extraction from URL and manual color picker work correctly
- Test @-mention autocomplete in workspace composer (patterns, components, data)
- Confirm theme persistence across page reloads via localStorage
- Validate that extracted brand colors cascade into all cre8-wc component shadows
- Check dark/light theme toggle applies consistently across shell and content
- Verify API routes (`/api/brand-extract`, `/api/a2ui-patterns`) return expected payloads

## Additional Information

The design system migration from `--cre8-*` to `--ui-*` tokens is scoped to the studio chrome and demo pages; agent-rendered cre8-wc components retain their original light theme on an always-light artboard, ensuring backward compatibility.

All demo data (patterns, data sources) lives in localStorage for full client-side operation; the remote container remains ephemeral.

https://claude.ai/code/session_01DYhTgB4VwwhZbHEfnBgn4o