### PR TITLE
Integrate WC Toolkit Storybook helpers and expose design tokens

### DIFF
--- a/packages/cre8-wc/.storybook/main.ts
+++ b/packages/cre8-wc/.storybook/main.ts
@@ -24,10 +24,11 @@ const config: StorybookConfig = {
     '@storybook/addon-a11y'
   ],
   // Customize Vite config
-  async viteFinal(config) {
+  async viteFinal(config, options) {
     const { mergeConfig } = await import('vite');
-    
-    return mergeConfig(config, {
+    const { storybookHelpersReloader } = await import('@wc-toolkit/storybook-helpers');
+
+    const merged = mergeConfig(config, {
       css: {
         preprocessorOptions: {
           scss: {
@@ -60,6 +61,13 @@ const config: StorybookConfig = {
         extensions: ['.ts', '.js', '.svg']
       }
     });
+
+    // Watch the Custom Elements Manifest so WC Toolkit Storybook helper
+    // controls (including design tokens) hot-reload when it is regenerated.
+    return storybookHelpersReloader({ path: 'custom-elements.json' }).viteFinal(
+      merged,
+      options,
+    );
   },
   framework: {
     name: '@storybook/web-components-vite',

--- a/packages/cre8-wc/.storybook/preview.ts
+++ b/packages/cre8-wc/.storybook/preview.ts
@@ -1,5 +1,6 @@
 import { setCustomElementsManifest } from '@storybook/web-components';
 import type { Preview } from '@storybook/web-components';
+import { setStorybookHelpersConfig } from '@wc-toolkit/storybook-helpers';
 
 import './css/styleguide-only.css';
 
@@ -23,6 +24,28 @@ document.head.appendChild(prismStyleElement);
 // import customElements from '!!json-loader!../loaders/wca-loader!../package.json';
 import customElements from './custom-elements.json';
 setCustomElementsManifest(customElements);
+
+// Configure the WC Toolkit Storybook helpers. These read the Custom Elements
+// Manifest set above to auto-generate controls for attributes, properties,
+// slots, events, CSS shadow parts, and — importantly — the design tokens
+// (CSS custom properties) each component exposes via `@cssproperty`.
+// See https://wc-toolkit.com/integrations/storybook/
+setStorybookHelpersConfig({
+  // Keep the "arg ref" hint visible so consumers can see which binding
+  // (attr/prop/css) each control maps to.
+  hideArgRef: false,
+  // Order controls so design tokens sit alongside the component API.
+  categoryOrder: [
+    'attributes',
+    'properties',
+    'slots',
+    'events',
+    'cssProps',
+    'cssParts',
+    'cssStates',
+    'methods',
+  ],
+});
 
 import headStyles from '../design-tokens/core/scss/theming/head.module.ts';
 

--- a/packages/cre8-wc/components/checkbox-field-item/checkbox-field-item.stories.ts
+++ b/packages/cre8-wc/components/checkbox-field-item/checkbox-field-item.stories.ts
@@ -1,47 +1,41 @@
-import { html } from 'lit';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 import '../field-note/field-note';
 import './checkbox-field-item';
-import { spread } from '../../directives/spread';
+import type { Cre8CheckboxFieldItem } from './checkbox-field-item';
 
-export default {
+// `getStorybookHelpers` reads the Custom Elements Manifest to auto-generate
+// controls for this component's attributes, properties, slots, events and the
+// design tokens (CSS custom properties) it exposes — here
+// `--cre8-border-radius-checkbox`. See https://wc-toolkit.com/integrations/storybook/
+const { args, argTypes, template } = getStorybookHelpers('cre8-checkbox-field-item');
+
+type Story = StoryObj<Cre8CheckboxFieldItem>;
+
+const meta: Meta<Cre8CheckboxFieldItem> = {
   title: 'cre8 Components/Checkbox Field Item',
   component: 'cre8-checkbox-field-item',
+  args,
+  argTypes,
   parameters: {
     status: { type: 'inProgress' },
     actions: {
       handles: ['input', 'change', 'blur', 'click']
     }
   },
-  render: (args) => html`<cre8-checkbox-field-item ${spread(args)}></cre8-checkbox-field-item>`,
+  render: (args) => template(args),
+};
+export default meta;
+
+export const Default: Story = {
   args: {
-    checked: undefined,
-    disabled: undefined,
-    errorNote: undefined,
-    fieldNote: undefined,
-    isError: undefined,
-    isSuccess: undefined,
     label: 'Label',
-    required: undefined,
-    successNote: undefined,
-    name: undefined
-  },
-  argTypes: {
-    checked: { control: 'boolean' },
-    disabled: { control: 'boolean' },
-    errorNote: { control: 'text' },
-    fieldNote: { control: 'text' },
-    fieldNoteIconName: { control: 'text' },
-    label: { control: 'text' },
-    successNote: { control: 'text' },
-    validationAriaDescribedBy: { control: 'text' },
-    name: { control: 'text', optional: true }
   },
 };
 
-export const Default = {};
-
-export const Preselected = {
+export const Preselected: Story = {
   args: {
+    label: 'Label',
     checked: true
   },
 };
@@ -51,14 +45,15 @@ export const Preselected = {
  *
  */
 
-export const Optional = {
+export const Optional: Story = {
   args: {
     label: 'Label (optional)'
   },
 };
 
-export const Error = {
+export const Error: Story = {
   args: {
+    label: 'Label',
     isError: true,
     required: true
   },
@@ -68,8 +63,9 @@ export const Error = {
  * Using disabled states is not advised. Ideally, never display unavailable actions.
  *
  */
-export const Disabled = {
+export const Disabled: Story = {
   args: {
+    label: 'Label',
     disabled: true
   },
 };
@@ -82,31 +78,46 @@ export const Disabled = {
  * and must include an associated `validationAriaDescribedBy` property.
  */
 
-export const DefaultWithFieldNote = {
+export const DefaultWithFieldNote: Story = {
   args: {
+    label: 'Label',
     fieldNote: 'This is a field note.',
     ariaDescribedBy: 'default-fieldnote-message',
   },
 };
 
-export const ErrorWithFieldNote = {
+export const ErrorWithFieldNote: Story = {
   args: {
+    label: 'Label',
     isError: true,
     errorNote: 'Short, clear error message',
     validationAriaDescribedBy: 'error-validation-message',
   },
 };
 
-export const SuccessWithFieldNote = {
+export const SuccessWithFieldNote: Story = {
   args: {
+    label: 'Label',
     isSuccess: true,
     successNote: 'Short, clear success message',
     validationAriaDescribedBy: 'success-valitation-message',
   },
 };
 
-export const LongTitle = {
+export const LongTitle: Story = {
   args: {
     label: 'This could mayhaps be the longest title that has ever been put on a checkbox field ever!'
+  },
+};
+
+/**
+ * The checkbox's corner radius is driven by the `--cre8-border-radius-checkbox`
+ * design token. Adjust it from the **CSS Custom Properties** controls (or the
+ * example below) to see it applied live.
+ */
+export const CustomBorderRadius: Story = {
+  args: {
+    label: 'Rounded checkbox',
+    '--cre8-border-radius-checkbox': '0.5rem',
   },
 };

--- a/packages/cre8-wc/components/pagination/pagination.stories.ts
+++ b/packages/cre8-wc/components/pagination/pagination.stories.ts
@@ -1,62 +1,46 @@
-import { html, nothing } from 'lit';
 import './pagination';
-import type { Meta, StoryObj } from '@storybook/web-components';
-import { cre8Pagination } from './pagination';
-import { withActions } from 'storybook/actions/decorator';
 import './page-counter/page-counter';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
+import { withActions } from 'storybook/actions/decorator';
+import type { Cre8Pagination } from './pagination';
 
+// `getStorybookHelpers` derives controls from the Custom Elements Manifest,
+// including the layout design tokens this component exposes:
+// `--pagination-display`, `--pagination-justify-content` and
+// `--pagination-align-items`. See https://wc-toolkit.com/integrations/storybook/
+const { args, argTypes, template } = getStorybookHelpers('cre8-pagination');
 
-interface Props extends Pick<cre8Pagination, 'currentPage' | 'totalResults' | 'pageSize' | 'display' | 'visiblePages' | 'hideLastAndFirstButtons'> {
-  currentPage: number,
-  totalResults: number;
-  pageSize: number;
-  visiblePages: number;
-  display: 'compact' | 'icon-only'| 'default',
-  hideFirstAndLastButtons: boolean
-}
-type Story = StoryObj<Props>;
+type Story = StoryObj<Cre8Pagination>;
 
-const meta: Meta= {
+const meta: Meta<Cre8Pagination> = {
   title: 'cre8 Components/Pagination',
   component: 'cre8-pagination',
   args: {
+    ...args,
     currentPage: 1,
     totalResults: 300,
     pageSize: 10,
     visiblePages: 5,
-    display: 'default'
+    display: 'default',
   },
   argTypes: {
+    ...argTypes,
     display: {
-      options: ['compact', 'icon-only','range', 'default'],
-      defaultValue: 'default',
-      control: { type: 'select' }
+      ...argTypes.display,
+      options: ['compact', 'icon-only', 'range', 'default'],
+      control: { type: 'select' },
     },
-    hideLastAndFirstButtons: {
-      control: { type: 'boolean' }
-    }
   },
   parameters: {
     status: { type: 'inProgress' },
     actions: {
-      handles: ['pagination.click','button.handleOnBlur', 'pagination.keydown'],
+      handles: ['pagination.click', 'button.handleOnBlur', 'pagination.keydown'],
     },
   },
   decorators: [withActions],
-
-  render: ({ currentPage, hideLastAndFirstButtons, totalResults, pageSize, display, visiblePages }) =>
-    html`
-    <cre8-pagination
-      currentPage="${currentPage}"
-      totalResults="${totalResults}"
-      pageSize="${pageSize}"
-      visiblePages="${visiblePages}"
-      display="${display}"
-      ?hideLastAndFirstButtons=${hideLastAndFirstButtons}
-      @pagination.click="${(e: Event) => console.log(e)}"
-      @pagination.keydown="${(e: Event) => console.log(e)}"
-    ></cre8-pagination>
-  `};
+  render: (args) => template(args),
+};
 export default meta;
 
 export const Default: Story = {
@@ -92,4 +76,3 @@ export const HideFirstAndLastButtons: Story = {
     hideLastAndFirstButtons: true
   }
 }
-

--- a/packages/cre8-wc/components/select-tile-list/select-tile-list.stories.ts
+++ b/packages/cre8-wc/components/select-tile-list/select-tile-list.stories.ts
@@ -1,31 +1,30 @@
 import { html } from 'lit-html';
-import type { Meta } from '@storybook/web-Components';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 import '../field-note/field-note';
 import './select-tile-list';
 import '../select-tile/select-tile';
+import type { Cre8SelectTileList } from './select-tile-list';
 
-const meta: Meta = {
-  title: 'In Development/Select Tile List',
-  component: 'cre8-select-tile-list',
-  parameters: { status: { type: 'beta' } },
-  decorators: [(story) => html`<form>\n${story()}\n</form>`],
-};
+// `getStorybookHelpers` derives controls from the Custom Elements Manifest,
+// including the `--cre8-select-tile-list-item-width` design token this
+// component exposes. See https://wc-toolkit.com/integrations/storybook/
+const { args, argTypes, template } = getStorybookHelpers('cre8-select-tile-list');
 
-export default meta;
+type Story = StoryObj<Cre8SelectTileList>;
 
-export const SelectTileList = () => html`<cre8-select-tile-list label="Legend" fieldNote="This is a Field Note!">
+// Reusable slotted tiles used to demonstrate the token-driven layout.
+const tiles = html`
   <cre8-select-tile name="t1" align="center" value="1">
     <cre8-icon-legacy slot="header" name="find-drug" style=" --cre8-icon-width: 56px;  --cre8-icon-height: 56px;"></cre8-icon-legacy>
     <span slot="title">Heading text</span>
     <span slot="body">Nunc amet vitae sit interdum non morbi fames ac sed</span>
   </cre8-select-tile>
-
   <cre8-select-tile ?isError=${true} name="t1" align="center" value="2">
     <cre8-icon-legacy slot="header" name="find-drug" style=" --cre8-icon-width: 56px;  --cre8-icon-height: 56px;"></cre8-icon-legacy>
     <span slot="title">Heading text</span>
     <span slot="body">Nunc amet vitae sit interdum non morbi fames ac sed</span>
   </cre8-select-tile>
-
   <cre8-select-tile ?isSuccess=${true} name="t1" align="center" value="3">
     <cre8-icon-legacy slot="header" name="find-drug" style=" --cre8-icon-width: 56px;  --cre8-icon-height: 56px;"></cre8-icon-legacy>
     <span slot="title">Heading text</span>
@@ -36,7 +35,27 @@ export const SelectTileList = () => html`<cre8-select-tile-list label="Legend" f
     <span slot="title">Heading text</span>
     <span slot="body">Nunc amet vitae sit interdum non morbi fames ac sed</span>
   </cre8-select-tile>
-</cre8-select-tile-list>`;
+`;
+
+const meta: Meta<Cre8SelectTileList> = {
+  title: 'In Development/Select Tile List',
+  component: 'cre8-select-tile-list',
+  args: {
+    ...args,
+    label: 'Legend',
+    fieldNote: 'This is a Field Note!',
+  },
+  argTypes,
+  parameters: { status: { type: 'beta' } },
+  decorators: [(story) => html`<form>\n${story()}\n</form>`],
+  // Render through the helper template so the `--cre8-select-tile-list-item-width`
+  // design token control is wired up live.
+  render: (args) => template(args, tiles),
+};
+
+export default meta;
+
+export const SelectTileList: Story = {};
 
 export const SelectTileListHorizontal = () => html`<cre8-select-tile-list variant="rows" label="Legend" fieldNote="This is a Field Note!">
   <cre8-select-tile name="t1" align="center" value="1" variant="horizontal">

--- a/packages/cre8-wc/package.json
+++ b/packages/cre8-wc/package.json
@@ -136,6 +136,7 @@
     "@typescript-eslint/eslint-plugin": "^8.46.3",
     "@typescript-eslint/parser": "^8.46.3",
     "@vitejs/plugin-react": "^5.2.0",
+    "@wc-toolkit/storybook-helpers": "^10.5.1",
     "babel-jest": "^30.2.0",
     "clone": "^2.1.2",
     "css-parse": "2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.2.0
         version: 5.2.0(vite@7.3.5)
+      '@wc-toolkit/storybook-helpers':
+        specifier: ^10.5.1
+        version: 10.5.1(lit@3.3.1)(storybook@10.3.5)
       babel-jest:
         specifier: ^30.2.0
         version: 30.3.0(@babel/core@7.29.7)
@@ -5164,6 +5167,16 @@ packages:
 
   /@vscode/web-custom-data@0.4.13:
     resolution: {integrity: sha512-2ZUIRfhofZ/npLlf872EBnPmn27Kt4M2UssmQIfnJvgGgMYZJ5fvtHEDnttBBf2hnVtBgNCqZMVHJA+wsFVqTA==}
+    dev: true
+
+  /@wc-toolkit/storybook-helpers@10.5.1(lit@3.3.1)(storybook@10.3.5):
+    resolution: {integrity: sha512-deS3LagKQVksbrXJZEQK8lgp+vTNUt8qiNFMAyLxzwTRa2sstQ7llNGLfeBTzx8c8GkWmSzYfoMMsc3ROfYiJQ==}
+    peerDependencies:
+      lit: ^2.0.0 || ^3.0.0
+      storybook: '>=10.1.11-0 <11.0.0-0'
+    dependencies:
+      lit: 3.3.1
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5)(react@19.2.5)
     dev: true
 
   /@web/config-loader@0.1.3:


### PR DESCRIPTION
Adopt @wc-toolkit/storybook-helpers to auto-generate Storybook controls
from the Custom Elements Manifest, including each component's design
tokens (CSS custom properties declared via @cssproperty).

- Add @wc-toolkit/storybook-helpers dev dependency
- Configure setStorybookHelpersConfig() in .storybook/preview.ts
- Wire storybookHelpersReloader into .storybook/main.ts viteFinal so
  controls hot-reload when custom-elements.json is regenerated
- Convert the token-declaring stories (checkbox-field-item, pagination,
  select-tile-list) to getStorybookHelpers so their CSS custom property
  tokens surface as live controls

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JBkFhaJUz5hDCuD8ThTTiA