### PR TITLE
Add compact A2UI catalog and the /a2ui/context retrieval endpoint

### DIFF
--- a/packages/cre8-mcp/dist/a2ui-context.d.ts
+++ b/packages/cre8-mcp/dist/a2ui-context.d.ts
@@ -1,0 +1,63 @@
+/**
+ * Context retrieval for the A2UI catalog.
+ *
+ * The full catalog is ~43k tokens, which is more than a small-context model can
+ * hold and more than a cloud model should pay for on every request. The compact
+ * projection — prop names, enum choices, required lists, slot names, containment
+ * — is ~7.5x smaller and carries the whole decoding constraint. Prose is what
+ * gets dropped.
+ *
+ * This is what lets one endpoint serve three very different callers: a cloud
+ * model taking the whole compact catalog, an on-device model taking a few hundred
+ * tokens of it, and an MCP host taking full prose for a narrow selection.
+ */
+export interface CompactPropSpec {
+    type?: string | string[];
+    enum?: string[];
+}
+export interface CompactComponent {
+    name: string;
+    category: string;
+    props?: Record<string, CompactPropSpec>;
+    required?: string[];
+    acceptsChildren?: boolean;
+    slots?: string[];
+}
+interface CompactCatalog {
+    contractVersion: number;
+    sourceCatalog: string;
+    libraryVersion: string;
+    componentCount: number;
+    components: CompactComponent[];
+}
+export declare function loadCompactCatalog(): CompactCatalog;
+export interface GetA2uiContextInput {
+    /** Explicit component names. Takes precedence over `categories`. */
+    names?: string[];
+    categories?: string[];
+    projection?: 'compact' | 'full';
+    /** Token ceiling. Whole components are dropped to fit; none is ever truncated. */
+    budget?: number;
+    /**
+     * Always admitted before the budget is spent elsewhere.
+     *
+     * Without this, filling smallest-first starves exactly the components worth
+     * keeping — definition size tracks prop count, so the most capable component in
+     * a category is the first casualty. Measured: a 1200-token budget over
+     * Forms/Actions/Typography dropped `cre8-button` and `cre8-field`, and the model
+     * substituted a checkbox for a password input.
+     */
+    pinned?: string[];
+}
+export interface A2uiContextResult {
+    contractVersion: number;
+    libraryVersion: string;
+    projection: 'compact' | 'full';
+    components: unknown[];
+    /** True when the budget forced components out. Callers must surface this. */
+    truncated: boolean;
+    droppedCount: number;
+    estimatedTokens: number;
+}
+export declare function handleGetA2uiContext(input: GetA2uiContextInput): A2uiContextResult;
+export {};

--- a/packages/cre8-mcp/dist/a2ui-context.js
+++ b/packages/cre8-mcp/dist/a2ui-context.js
@@ -1,0 +1,109 @@
+/**
+ * Context retrieval for the A2UI catalog.
+ *
+ * The full catalog is ~43k tokens, which is more than a small-context model can
+ * hold and more than a cloud model should pay for on every request. The compact
+ * projection — prop names, enum choices, required lists, slot names, containment
+ * — is ~7.5x smaller and carries the whole decoding constraint. Prose is what
+ * gets dropped.
+ *
+ * This is what lets one endpoint serve three very different callers: a cloud
+ * model taking the whole compact catalog, an on-device model taking a few hundred
+ * tokens of it, and an MCP host taking full prose for a narrow selection.
+ */
+import { readFileSync } from 'fs';
+import { createRequire } from 'module';
+import { loadA2uiCatalog } from './handlers.js';
+let compactCache = null;
+export function loadCompactCatalog() {
+    if (compactCache)
+        return compactCache;
+    const require = createRequire(import.meta.url);
+    const path = require.resolve('@tmorrow/cre8-wc/a2ui/catalog.compact.json');
+    compactCache = JSON.parse(readFileSync(path, 'utf-8'));
+    return compactCache;
+}
+/**
+ * Bytes/4. Deliberately provider-agnostic: the plane cannot know which tokenizer
+ * the caller's model uses, so it offers a consistent, slightly conservative
+ * estimate and lets clients with a real tokenizer do their own accounting.
+ */
+function estimateTokens(value) {
+    return Math.max(1, Math.ceil(JSON.stringify(value).length / 4));
+}
+function normalize(name) {
+    return name.startsWith('cre8-') ? name : `cre8-${name}`;
+}
+export function handleGetA2uiContext(input) {
+    const compact = loadCompactCatalog();
+    const projection = input.projection ?? 'compact';
+    const byName = new Map(compact.components.map((c) => [c.name, c]));
+    let candidates;
+    if (input.names?.length) {
+        candidates = input.names.map((raw) => {
+            const name = normalize(raw);
+            const found = byName.get(name);
+            if (!found) {
+                throw new Error(`Component "${name}" not found in A2UI catalog.`);
+            }
+            return found;
+        });
+    }
+    else if (input.categories?.length) {
+        const wanted = new Set(input.categories);
+        candidates = compact.components.filter((c) => wanted.has(c.category));
+        if (candidates.length === 0) {
+            const available = [...new Set(compact.components.map((c) => c.category))].sort().join(', ');
+            throw new Error(`No components in categories [${input.categories.join(', ')}]. Available: ${available}`);
+        }
+    }
+    else {
+        candidates = compact.components;
+    }
+    // `full` reaches back into the real catalog for the prose-bearing definitions.
+    const materialize = (component) => {
+        if (projection === 'compact')
+            return component;
+        const definition = loadA2uiCatalog().components.get(component.name);
+        return { name: component.name, definition };
+    };
+    if (input.budget === undefined) {
+        const components = candidates.map(materialize);
+        return {
+            contractVersion: compact.contractVersion,
+            libraryVersion: compact.libraryVersion,
+            projection,
+            components,
+            truncated: false,
+            droppedCount: 0,
+            estimatedTokens: estimateTokens(components),
+        };
+    }
+    const pinned = new Set((input.pinned ?? []).map(normalize));
+    const ordered = [
+        ...candidates.filter((c) => pinned.has(c.name)),
+        ...candidates
+            .filter((c) => !pinned.has(c.name))
+            .sort((a, b) => JSON.stringify(a).length - JSON.stringify(b).length),
+    ];
+    const kept = [];
+    let used = 0;
+    for (const component of ordered) {
+        const cost = estimateTokens(materialize(component));
+        if (used + cost > input.budget)
+            continue;
+        kept.push(component);
+        used += cost;
+    }
+    kept.sort((a, b) => a.name.localeCompare(b.name));
+    const components = kept.map(materialize);
+    return {
+        contractVersion: compact.contractVersion,
+        libraryVersion: compact.libraryVersion,
+        projection,
+        components,
+        truncated: kept.length < candidates.length,
+        droppedCount: candidates.length - kept.length,
+        estimatedTokens: used,
+    };
+}

--- a/packages/cre8-mcp/dist/app.js
+++ b/packages/cre8-mcp/dist/app.js
@@ -12,6 +12,7 @@
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { handleGetPatterns, handleSearchComponents, handleListComponents, handleGetComponent, handleGenerateCode, handleGetA2uiCatalog, handleValidateA2uiSpec, } from './handlers.js';
+import { handleGetA2uiContext } from './a2ui-context.js';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import { Cre8GuideSchema, GetContentModelSchema, handleCre8Guide, handleGetContentModel } from './knowledge-tools.js';
 import { GetCompositionSchema, handleGetComposition } from './composition.js';
@@ -257,6 +258,37 @@ export function createApp(options = {}) {
         catch (err) {
             const msg = err instanceof Error ? err.message : 'Unknown error';
             return c.json({ error: msg }, 404);
+        }
+    });
+    /**
+     * The retrieval endpoint. Serves a slice of the catalog sized to the caller's
+     * context, rather than making every caller take all ~43k tokens of it.
+     *
+     *   GET /a2ui/context?projection=compact&categories=Forms,Actions&budget=1500
+     */
+    app.get('/a2ui/context', (c) => {
+        const csv = (key) => c.req.query(key)?.split(',').map((s) => s.trim()).filter(Boolean);
+        const budgetRaw = c.req.query('budget');
+        const budget = budgetRaw === undefined ? undefined : Number(budgetRaw);
+        if (budget !== undefined && (!Number.isFinite(budget) || budget <= 0)) {
+            return c.json({ error: '`budget` must be a positive number of tokens' }, 400);
+        }
+        const projection = c.req.query('projection');
+        if (projection !== undefined && projection !== 'compact' && projection !== 'full') {
+            return c.json({ error: '`projection` must be "compact" or "full"' }, 400);
+        }
+        try {
+            return c.json(handleGetA2uiContext({
+                names: csv('names'),
+                categories: csv('categories'),
+                projection,
+                budget,
+                pinned: csv('pinned'),
+            }));
+        }
+        catch (err) {
+            const msg = err instanceof Error ? err.message : 'Unknown error';
+            return c.json({ error: msg }, 400);
         }
     });
     app.post('/a2ui/validate', async (c) => {

--- a/packages/cre8-mcp/package.json
+++ b/packages/cre8-mcp/package.json
@@ -15,7 +15,7 @@
     "start": "node dist/index.js",
     "start:api": "node dist/server.js",
     "dev:api": "npx tsx watch src/server.ts",
-    "test": "npx tsx test/surface-api.test.mjs && npx tsx test/stdio-viewer.test.mjs"
+    "test": "npx tsx test/surface-api.test.mjs && npx tsx test/stdio-viewer.test.mjs && npx tsx test/a2ui-context.test.mjs"
   },
   "keywords": [
     "mcp",

--- a/packages/cre8-mcp/src/a2ui-context.ts
+++ b/packages/cre8-mcp/src/a2ui-context.ts
@@ -1,0 +1,172 @@
+/**
+ * Context retrieval for the A2UI catalog.
+ *
+ * The full catalog is ~43k tokens, which is more than a small-context model can
+ * hold and more than a cloud model should pay for on every request. The compact
+ * projection — prop names, enum choices, required lists, slot names, containment
+ * — is ~7.5x smaller and carries the whole decoding constraint. Prose is what
+ * gets dropped.
+ *
+ * This is what lets one endpoint serve three very different callers: a cloud
+ * model taking the whole compact catalog, an on-device model taking a few hundred
+ * tokens of it, and an MCP host taking full prose for a narrow selection.
+ */
+
+import { readFileSync } from 'fs';
+import { createRequire } from 'module';
+import { loadA2uiCatalog } from './handlers.js';
+
+export interface CompactPropSpec {
+  type?: string | string[];
+  enum?: string[];
+}
+
+export interface CompactComponent {
+  name: string;
+  category: string;
+  props?: Record<string, CompactPropSpec>;
+  required?: string[];
+  acceptsChildren?: boolean;
+  slots?: string[];
+}
+
+interface CompactCatalog {
+  contractVersion: number;
+  sourceCatalog: string;
+  libraryVersion: string;
+  componentCount: number;
+  components: CompactComponent[];
+}
+
+let compactCache: CompactCatalog | null = null;
+
+export function loadCompactCatalog(): CompactCatalog {
+  if (compactCache) return compactCache;
+  const require = createRequire(import.meta.url);
+  const path = require.resolve('@tmorrow/cre8-wc/a2ui/catalog.compact.json');
+  compactCache = JSON.parse(readFileSync(path, 'utf-8')) as CompactCatalog;
+  return compactCache;
+}
+
+export interface GetA2uiContextInput {
+  /** Explicit component names. Takes precedence over `categories`. */
+  names?: string[];
+  categories?: string[];
+  projection?: 'compact' | 'full';
+  /** Token ceiling. Whole components are dropped to fit; none is ever truncated. */
+  budget?: number;
+  /**
+   * Always admitted before the budget is spent elsewhere.
+   *
+   * Without this, filling smallest-first starves exactly the components worth
+   * keeping — definition size tracks prop count, so the most capable component in
+   * a category is the first casualty. Measured: a 1200-token budget over
+   * Forms/Actions/Typography dropped `cre8-button` and `cre8-field`, and the model
+   * substituted a checkbox for a password input.
+   */
+  pinned?: string[];
+}
+
+export interface A2uiContextResult {
+  contractVersion: number;
+  libraryVersion: string;
+  projection: 'compact' | 'full';
+  components: unknown[];
+  /** True when the budget forced components out. Callers must surface this. */
+  truncated: boolean;
+  droppedCount: number;
+  estimatedTokens: number;
+}
+
+/**
+ * Bytes/4. Deliberately provider-agnostic: the plane cannot know which tokenizer
+ * the caller's model uses, so it offers a consistent, slightly conservative
+ * estimate and lets clients with a real tokenizer do their own accounting.
+ */
+function estimateTokens(value: unknown): number {
+  return Math.max(1, Math.ceil(JSON.stringify(value).length / 4));
+}
+
+function normalize(name: string): string {
+  return name.startsWith('cre8-') ? name : `cre8-${name}`;
+}
+
+export function handleGetA2uiContext(input: GetA2uiContextInput): A2uiContextResult {
+  const compact = loadCompactCatalog();
+  const projection = input.projection ?? 'compact';
+
+  const byName = new Map(compact.components.map((c) => [c.name, c]));
+
+  let candidates: CompactComponent[];
+  if (input.names?.length) {
+    candidates = input.names.map((raw) => {
+      const name = normalize(raw);
+      const found = byName.get(name);
+      if (!found) {
+        throw new Error(`Component "${name}" not found in A2UI catalog.`);
+      }
+      return found;
+    });
+  } else if (input.categories?.length) {
+    const wanted = new Set(input.categories);
+    candidates = compact.components.filter((c) => wanted.has(c.category));
+    if (candidates.length === 0) {
+      const available = [...new Set(compact.components.map((c) => c.category))].sort().join(', ');
+      throw new Error(
+        `No components in categories [${input.categories.join(', ')}]. Available: ${available}`
+      );
+    }
+  } else {
+    candidates = compact.components;
+  }
+
+  // `full` reaches back into the real catalog for the prose-bearing definitions.
+  const materialize = (component: CompactComponent): unknown => {
+    if (projection === 'compact') return component;
+    const definition = loadA2uiCatalog().components.get(component.name);
+    return { name: component.name, definition };
+  };
+
+  if (input.budget === undefined) {
+    const components = candidates.map(materialize);
+    return {
+      contractVersion: compact.contractVersion,
+      libraryVersion: compact.libraryVersion,
+      projection,
+      components,
+      truncated: false,
+      droppedCount: 0,
+      estimatedTokens: estimateTokens(components),
+    };
+  }
+
+  const pinned = new Set((input.pinned ?? []).map(normalize));
+  const ordered = [
+    ...candidates.filter((c) => pinned.has(c.name)),
+    ...candidates
+      .filter((c) => !pinned.has(c.name))
+      .sort((a, b) => JSON.stringify(a).length - JSON.stringify(b).length),
+  ];
+
+  const kept: CompactComponent[] = [];
+  let used = 0;
+  for (const component of ordered) {
+    const cost = estimateTokens(materialize(component));
+    if (used + cost > input.budget) continue;
+    kept.push(component);
+    used += cost;
+  }
+
+  kept.sort((a, b) => a.name.localeCompare(b.name));
+  const components = kept.map(materialize);
+
+  return {
+    contractVersion: compact.contractVersion,
+    libraryVersion: compact.libraryVersion,
+    projection,
+    components,
+    truncated: kept.length < candidates.length,
+    droppedCount: candidates.length - kept.length,
+    estimatedTokens: used,
+  };
+}

--- a/packages/cre8-mcp/src/app.ts
+++ b/packages/cre8-mcp/src/app.ts
@@ -22,6 +22,7 @@ import {
   handleValidateA2uiSpec,
 } from './handlers.js';
 import type { GetPatternsInput, SearchComponentsInput, GenerateCodeInput } from './handlers.js';
+import { handleGetA2uiContext } from './a2ui-context.js';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import { Cre8GuideSchema, GetContentModelSchema, handleCre8Guide, handleGetContentModel } from './knowledge-tools.js';
 import { GetCompositionSchema, handleGetComposition } from './composition.js';
@@ -297,6 +298,43 @@ export function createApp(options: AppOptions = {}): Hono {
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Unknown error';
       return c.json({ error: msg }, 404);
+    }
+  });
+
+  /**
+   * The retrieval endpoint. Serves a slice of the catalog sized to the caller's
+   * context, rather than making every caller take all ~43k tokens of it.
+   *
+   *   GET /a2ui/context?projection=compact&categories=Forms,Actions&budget=1500
+   */
+  app.get('/a2ui/context', (c) => {
+    const csv = (key: string) =>
+      c.req.query(key)?.split(',').map((s) => s.trim()).filter(Boolean);
+    const budgetRaw = c.req.query('budget');
+    const budget = budgetRaw === undefined ? undefined : Number(budgetRaw);
+
+    if (budget !== undefined && (!Number.isFinite(budget) || budget <= 0)) {
+      return c.json({ error: '`budget` must be a positive number of tokens' }, 400);
+    }
+
+    const projection = c.req.query('projection');
+    if (projection !== undefined && projection !== 'compact' && projection !== 'full') {
+      return c.json({ error: '`projection` must be "compact" or "full"' }, 400);
+    }
+
+    try {
+      return c.json(
+        handleGetA2uiContext({
+          names: csv('names'),
+          categories: csv('categories'),
+          projection,
+          budget,
+          pinned: csv('pinned'),
+        })
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      return c.json({ error: msg }, 400);
     }
   });
 

--- a/packages/cre8-mcp/test/a2ui-context.test.mjs
+++ b/packages/cre8-mcp/test/a2ui-context.test.mjs
@@ -1,0 +1,137 @@
+/**
+ * HTTP-level tests for GET /a2ui/context.
+ *
+ *   npx tsx test/a2ui-context.test.mjs
+ *
+ * Drives the Hono app directly with `app.request()` — no port, no sockets.
+ */
+
+const { createApp } = await import('../src/app.ts');
+
+const app = createApp({ port: 3999, token: '' });
+
+let passed = 0;
+const failures = [];
+
+async function test(name, fn) {
+  try {
+    await fn();
+    passed++;
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    failures.push(name);
+    console.log(`FAIL  ${name}\n      ${err.message}`);
+  }
+}
+
+function assert(cond, message) {
+  if (!cond) throw new Error(message ?? 'assertion failed');
+}
+
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message ?? 'not equal'}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+const get = async (path) => {
+  const res = await app.request(path);
+  return { status: res.status, body: await res.json() };
+};
+
+await test('the whole catalog comes back compact and untruncated', async () => {
+  const { status, body } = await get('/a2ui/context');
+  assertEqual(status, 200);
+  assertEqual(body.projection, 'compact');
+  assertEqual(body.truncated, false);
+  assertEqual(body.droppedCount, 0);
+  assert(body.components.length > 80, 'expected the full catalog');
+  assertEqual(body.contractVersion, 1);
+});
+
+await test('compact is dramatically smaller than full for the same selection', async () => {
+  const compact = await get('/a2ui/context?names=cre8-button');
+  const full = await get('/a2ui/context?names=cre8-button&projection=full');
+  assert(
+    full.body.estimatedTokens > compact.body.estimatedTokens * 3,
+    `expected a large gap, got compact=${compact.body.estimatedTokens} full=${full.body.estimatedTokens}`
+  );
+});
+
+await test('containment survives the projection, so containers are not mistaken for leaves', async () => {
+  const { body } = await get('/a2ui/context?names=cre8-layout-container,cre8-card');
+  const container = body.components.find((c) => c.name === 'cre8-layout-container');
+  const card = body.components.find((c) => c.name === 'cre8-card');
+  assertEqual(container.acceptsChildren, true, 'layout-container takes children');
+  assert(card.slots?.includes('default'), 'card has a default slot');
+});
+
+await test('enum choices survive, because they are the decoding constraint', async () => {
+  const { body } = await get('/a2ui/context?names=cre8-button');
+  const variant = body.components[0].props.variant;
+  assert(variant.enum?.includes('primary'), 'variant must keep its choices');
+});
+
+await test('a budget drops whole components and reports how many', async () => {
+  const { body } = await get('/a2ui/context?budget=500');
+  assertEqual(body.truncated, true);
+  assert(body.droppedCount > 0, 'expected drops');
+  assert(body.estimatedTokens <= 500, `over budget: ${body.estimatedTokens}`);
+  // Every survivor must still be a complete definition.
+  for (const component of body.components) {
+    assert(typeof component.name === 'string' && component.name.length > 0, 'truncated component');
+  }
+});
+
+await test('pinned components survive a budget that would otherwise drop them', async () => {
+  const tight = '/a2ui/context?categories=Forms,Actions,Typography&budget=1200';
+  const unpinned = await get(tight);
+  const pinned = await get(`${tight}&pinned=cre8-button,cre8-field`);
+
+  const names = (r) => r.body.components.map((c) => c.name);
+  // The regression this guards: size tracks prop count, so the most capable
+  // components are the first casualties of smallest-first filling.
+  assert(!names(unpinned).includes('cre8-button'), 'precondition: button is starved unpinned');
+  assert(names(pinned).includes('cre8-button'), 'pinning must rescue cre8-button');
+  assert(names(pinned).includes('cre8-field'), 'pinning must rescue cre8-field');
+});
+
+await test('category selection narrows the slice', async () => {
+  const { body } = await get('/a2ui/context?categories=Actions');
+  assert(body.components.length > 0, 'expected some Actions components');
+  assert(body.components.every((c) => c.category === 'Actions'), 'leaked a non-Actions component');
+});
+
+await test('an unknown component name is an error, not a silent omission', async () => {
+  const { status, body } = await get('/a2ui/context?names=cre8-not-a-component');
+  assertEqual(status, 400);
+  assert(body.error.includes('not found'), body.error);
+});
+
+await test('an unknown category lists what is available rather than returning nothing', async () => {
+  const { status, body } = await get('/a2ui/context?categories=Nonsense');
+  assertEqual(status, 400);
+  assert(body.error.includes('Available:'), body.error);
+});
+
+await test('a malformed budget is rejected rather than silently ignored', async () => {
+  assertEqual((await get('/a2ui/context?budget=abc')).status, 400);
+  assertEqual((await get('/a2ui/context?budget=-5')).status, 400);
+});
+
+await test('an unknown projection is rejected', async () => {
+  const { status } = await get('/a2ui/context?projection=medium');
+  assertEqual(status, 400);
+});
+
+await test('the route sits behind the bearer gate like every other', async () => {
+  const guarded = createApp({ port: 3999, token: 'secret' });
+  assertEqual((await guarded.request('/a2ui/context')).status, 401);
+  const ok = await guarded.request('/a2ui/context', {
+    headers: { authorization: 'Bearer secret' },
+  });
+  assertEqual(ok.status, 200);
+});
+
+console.log(`\n${passed} passed, ${failures.length} failed`);
+if (failures.length) process.exit(1);

--- a/packages/cre8-wc/a2ui/catalog.compact.json
+++ b/packages/cre8-wc/a2ui/catalog.compact.json
@@ -1,0 +1,2412 @@
+{
+  "contractVersion": 1,
+  "sourceCatalog": "https://cre8.dev/a2ui/catalogs/cre8-wc/2.0.7",
+  "libraryVersion": "2.0.7",
+  "componentCount": 85,
+  "components": [
+    {
+      "name": "cre8-accordion",
+      "category": "Disclosure",
+      "props": {
+        "items": {
+          "type": "array"
+        },
+        "borderType": {
+          "enum": [
+            "rectangle",
+            "rounded-bottom",
+            "rounded",
+            "none"
+          ]
+        },
+        "hasDivider": {
+          "type": "boolean"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-accordion-item",
+      "category": "Disclosure",
+      "props": {
+        "size": {
+          "enum": [
+            "sm",
+            "lg"
+          ]
+        },
+        "heading": {
+          "type": "string"
+        },
+        "isActive": {
+          "type": "boolean"
+        },
+        "iconBefore": {
+          "type": "boolean"
+        },
+        "tertiaryIcon": {
+          "type": "boolean"
+        },
+        "headingTagVariant": {
+          "enum": [
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            "h5",
+            "h6"
+          ]
+        },
+        "brandHeader": {
+          "type": "boolean"
+        },
+        "accordionItemId": {
+          "type": "string"
+        }
+      },
+      "slots": [
+        "default",
+        "heading"
+      ]
+    },
+    {
+      "name": "cre8-alert",
+      "category": "Feedback",
+      "props": {
+        "status": {
+          "enum": [
+            "error",
+            "info",
+            "notification",
+            "neutral",
+            "warning",
+            "success"
+          ]
+        },
+        "variant": {
+          "enum": [
+            "standalone",
+            "banner"
+          ]
+        },
+        "emphasis": {
+          "enum": [
+            "subtle",
+            "strong"
+          ]
+        },
+        "dismissed": {
+          "type": "boolean"
+        },
+        "iconAlert": {
+          "type": "string"
+        },
+        "iconTitle": {
+          "type": "string"
+        },
+        "headerText": {
+          "type": "string"
+        },
+        "ctaBody": {
+          "type": "string"
+        },
+        "notDismissible": {
+          "type": "boolean"
+        }
+      },
+      "slots": [
+        "default",
+        "cta"
+      ]
+    },
+    {
+      "name": "cre8-badge",
+      "category": "Feedback",
+      "props": {
+        "text": {
+          "type": "string"
+        },
+        "status": {
+          "enum": [
+            "error",
+            "info",
+            "warning",
+            "success",
+            "attention"
+          ]
+        },
+        "variant": {
+          "enum": [
+            "light",
+            "white"
+          ]
+        },
+        "svg": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "name": "cre8-band",
+      "category": "Layout",
+      "props": {
+        "variant": {
+          "type": "string"
+        },
+        "fullHeight": {
+          "type": "boolean"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-breadcrumbs",
+      "category": "Navigation",
+      "props": {
+        "items": {
+          "type": "array"
+        },
+        "navAriaLabel": {
+          "type": "string"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-breadcrumbs-item",
+      "category": "Navigation",
+      "props": {},
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-button",
+      "category": "Actions",
+      "props": {
+        "text": {
+          "type": "string"
+        },
+        "variant": {
+          "enum": [
+            "primary",
+            "secondary",
+            "tertiary"
+          ]
+        },
+        "neutral": {
+          "type": "boolean"
+        },
+        "inverse": {
+          "type": "boolean"
+        },
+        "href": {
+          "type": "string"
+        },
+        "target": {
+          "enum": [
+            "_blank",
+            "_self",
+            "_parent",
+            "_top"
+          ]
+        },
+        "rel": {
+          "type": "string"
+        },
+        "svg": {
+          "type": "string"
+        },
+        "size": {
+          "enum": [
+            "sm",
+            "lg",
+            "md"
+          ]
+        },
+        "loading": {
+          "type": "boolean"
+        },
+        "type": {
+          "enum": [
+            "button",
+            "submit",
+            "reset"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "value": {
+          "type": "string"
+        },
+        "iconName": {
+          "type": "string"
+        },
+        "iconRotateDegree": {
+          "type": "number"
+        },
+        "iconFlipDirection": {
+          "type": "string"
+        },
+        "iconPosition": {
+          "enum": [
+            "before",
+            "after"
+          ]
+        },
+        "hideText": {
+          "type": "boolean"
+        },
+        "fullWidth": {
+          "type": "boolean"
+        },
+        "loadingComplete": {
+          "type": "boolean"
+        },
+        "ariaLive": {
+          "enum": [
+            "polite",
+            "assertive"
+          ]
+        },
+        "splitButtonType": {
+          "enum": [
+            "text",
+            "caret"
+          ]
+        },
+        "buttonAriaExpanded": {
+          "type": "boolean"
+        },
+        "isError": {
+          "type": "boolean"
+        },
+        "isSuccess": {
+          "type": "boolean"
+        }
+      },
+      "slots": [
+        "before",
+        "after"
+      ]
+    },
+    {
+      "name": "cre8-button-group",
+      "category": "Actions",
+      "props": {
+        "orientation": {
+          "type": "string"
+        },
+        "gap": {
+          "type": "string"
+        },
+        "fullWidth": {
+          "type": "boolean"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-card",
+      "category": "Layout",
+      "props": {
+        "variant": {
+          "enum": [
+            "bare",
+            "compact",
+            "horizontal",
+            "horizontal-bare"
+          ]
+        },
+        "align": {
+          "type": "string"
+        }
+      },
+      "slots": [
+        "default",
+        "header",
+        "footer"
+      ]
+    },
+    {
+      "name": "cre8-chart",
+      "category": "Data",
+      "props": {
+        "type": {
+          "enum": [
+            "line",
+            "bar",
+            "pie",
+            "doughnut",
+            "radar",
+            "polarArea",
+            "bubble",
+            "scatter"
+          ]
+        },
+        "width": {
+          "type": "number"
+        },
+        "height": {
+          "type": "number"
+        },
+        "maintain-aspect-ratio": {
+          "type": "boolean"
+        },
+        "responsive": {
+          "type": "boolean"
+        },
+        "loading": {
+          "type": "boolean"
+        },
+        "aria-label": {
+          "type": "string"
+        },
+        "show-legend": {
+          "type": "boolean"
+        },
+        "legend-position": {
+          "enum": [
+            "top",
+            "bottom",
+            "left",
+            "right"
+          ]
+        },
+        "enable-animation": {
+          "type": "boolean"
+        },
+        "animation-duration": {
+          "type": "number"
+        },
+        "data": {
+          "type": "object"
+        },
+        "options": {
+          "type": "object"
+        },
+        "colors": {
+          "type": "array"
+        }
+      }
+    },
+    {
+      "name": "cre8-checkbox-field",
+      "category": "Forms",
+      "props": {
+        "label": {
+          "type": "string"
+        },
+        "items": {
+          "type": "array"
+        },
+        "name": {
+          "type": "string"
+        },
+        "fieldNote": {
+          "type": "string"
+        },
+        "ariaDescribedBy": {
+          "type": "string"
+        },
+        "fieldNoteIconName": {
+          "type": "string"
+        },
+        "fieldNoteKnockout": {
+          "type": "boolean"
+        },
+        "fieldNoteIsSuccess": {
+          "type": "boolean"
+        },
+        "fieldNoteIsError": {
+          "type": "boolean"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-checkbox-field-item",
+      "category": "Forms",
+      "props": {
+        "label": {
+          "type": "string"
+        },
+        "checked": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "value": {
+          "type": "string"
+        },
+        "errorText": {
+          "type": "string"
+        },
+        "errorNote": {
+          "type": "string"
+        },
+        "successText": {
+          "type": "string"
+        },
+        "successNote": {
+          "type": "string"
+        },
+        "fieldId": {
+          "type": "string"
+        },
+        "fieldNote": {
+          "type": "string"
+        },
+        "ariaDescribedBy": {
+          "type": "string"
+        },
+        "validationAriaDescribedBy": {
+          "type": "string"
+        },
+        "fieldNoteIconName": {
+          "type": "string"
+        },
+        "isError": {
+          "type": "boolean"
+        },
+        "isSuccess": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "slots": [
+        "fieldNote"
+      ]
+    },
+    {
+      "name": "cre8-danger-button",
+      "category": "Actions",
+      "props": {
+        "text": {
+          "type": "string"
+        },
+        "variant": {
+          "enum": [
+            "primary",
+            "secondary",
+            "tertiary"
+          ]
+        },
+        "href": {
+          "type": "string"
+        },
+        "target": {
+          "enum": [
+            "_blank",
+            "_self",
+            "_parent",
+            "_top"
+          ]
+        },
+        "rel": {
+          "type": "string"
+        },
+        "svg": {
+          "type": "string"
+        },
+        "size": {
+          "enum": [
+            "sm",
+            "lg"
+          ]
+        },
+        "loading": {
+          "type": "boolean"
+        },
+        "inverted": {
+          "type": "boolean"
+        },
+        "type": {
+          "enum": [
+            "button",
+            "submit",
+            "reset"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "value": {
+          "type": "string"
+        },
+        "iconRotateDegree": {
+          "type": "number"
+        },
+        "iconFlipDirection": {
+          "type": "string"
+        },
+        "iconPosition": {
+          "enum": [
+            "before",
+            "after"
+          ]
+        },
+        "hideText": {
+          "type": "boolean"
+        },
+        "fullWidth": {
+          "type": "boolean"
+        },
+        "loadingComplete": {
+          "type": "boolean"
+        },
+        "ariaLive": {
+          "enum": [
+            "polite",
+            "assertive"
+          ]
+        },
+        "buttonAriaExpanded": {
+          "type": "boolean"
+        },
+        "isError": {
+          "type": "boolean"
+        },
+        "isSuccess": {
+          "type": "boolean"
+        }
+      }
+    },
+    {
+      "name": "cre8-date-picker",
+      "category": "Forms",
+      "props": {
+        "autocomplete": {
+          "type": "string"
+        },
+        "pattern": {
+          "type": "string"
+        },
+        "placeholder": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "max": {
+          "type": [
+            "string",
+            "number"
+          ]
+        },
+        "min": {
+          "type": [
+            "string",
+            "number"
+          ]
+        },
+        "maxlength": {
+          "type": "string"
+        },
+        "readonly": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "value": {
+          "type": "string"
+        },
+        "hasShortcuts": {
+          "type": "boolean"
+        },
+        "fieldId": {
+          "type": "string"
+        },
+        "fieldNote": {
+          "type": "string"
+        },
+        "ariaLive": {
+          "enum": [
+            "polite",
+            "assertive"
+          ]
+        },
+        "ariaDescribedBy": {
+          "type": "string"
+        },
+        "errorText": {
+          "type": "string"
+        },
+        "errorNote": {
+          "type": "string"
+        },
+        "validationAriaDescribedBy": {
+          "type": "string"
+        },
+        "successText": {
+          "type": "string"
+        },
+        "successNote": {
+          "type": "string"
+        },
+        "isError": {
+          "type": "boolean"
+        },
+        "isSuccess": {
+          "type": "boolean"
+        },
+        "showCalendar": {
+          "type": "boolean"
+        }
+      },
+      "slots": [
+        "fieldNote"
+      ]
+    },
+    {
+      "name": "cre8-divider",
+      "category": "Layout",
+      "props": {
+        "variant": {
+          "enum": [
+            "horizontal",
+            "vertical"
+          ]
+        },
+        "status": {
+          "enum": [
+            "brand",
+            "knockout"
+          ]
+        }
+      }
+    },
+    {
+      "name": "cre8-dropdown",
+      "category": "Disclosure",
+      "props": {
+        "items": {
+          "type": "array"
+        },
+        "buttonText": {
+          "type": "string"
+        },
+        "maxHeight": {
+          "type": "string"
+        },
+        "dropdownWithLink": {
+          "type": "boolean"
+        },
+        "open": {
+          "type": "boolean"
+        },
+        "dropdownContent": {
+          "type": "string"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-dropdown-item",
+      "category": "Disclosure",
+      "props": {
+        "ariaLabel": {
+          "type": "string"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-feature",
+      "category": "Marketing",
+      "props": {
+        "inverted": {
+          "type": "boolean"
+        },
+        "imgSrc": {
+          "type": "string"
+        },
+        "imgAlt": {
+          "type": "string"
+        },
+        "aspectRatio": {
+          "type": "string"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-field",
+      "category": "Forms",
+      "props": {
+        "autocomplete": {
+          "type": "string"
+        },
+        "pattern": {
+          "type": "string"
+        },
+        "placeholder": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "max": {
+          "type": [
+            "string",
+            "number"
+          ]
+        },
+        "min": {
+          "type": [
+            "string",
+            "number"
+          ]
+        },
+        "maxlength": {
+          "type": "string"
+        },
+        "readonly": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "value": {
+          "type": "string"
+        },
+        "fieldId": {
+          "type": "string"
+        },
+        "fieldNote": {
+          "type": "string"
+        },
+        "ariaLive": {
+          "enum": [
+            "polite",
+            "assertive"
+          ]
+        },
+        "ariaDescribedBy": {
+          "type": "string"
+        },
+        "errorText": {
+          "type": "string"
+        },
+        "errorNote": {
+          "type": "string"
+        },
+        "validationAriaDescribedBy": {
+          "type": "string"
+        },
+        "successText": {
+          "type": "string"
+        },
+        "successNote": {
+          "type": "string"
+        },
+        "isError": {
+          "type": "boolean"
+        },
+        "isSuccess": {
+          "type": "boolean"
+        }
+      },
+      "slots": [
+        "fieldNote"
+      ]
+    },
+    {
+      "name": "cre8-field-note",
+      "category": "Forms",
+      "props": {
+        "isError": {
+          "type": "boolean"
+        },
+        "isSuccess": {
+          "type": "boolean"
+        },
+        "iconName": {
+          "type": "string"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-footer",
+      "category": "Navigation",
+      "props": {},
+      "slots": [
+        "default",
+        "top",
+        "bottom"
+      ]
+    },
+    {
+      "name": "cre8-global-nav",
+      "category": "Navigation",
+      "props": {
+        "inverted": {
+          "type": "boolean"
+        },
+        "behavior": {
+          "type": "string"
+        },
+        "navAriaLabel": {
+          "type": "string"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-global-nav-item",
+      "category": "Navigation",
+      "props": {
+        "text": {
+          "type": "string"
+        },
+        "href": {
+          "type": "string"
+        },
+        "iconName": {
+          "type": "string"
+        },
+        "megaMenu": {
+          "type": "boolean"
+        },
+        "isActive": {
+          "type": "boolean"
+        }
+      },
+      "slots": [
+        "default",
+        "itemBefore",
+        "itemAfter"
+      ]
+    },
+    {
+      "name": "cre8-grid",
+      "category": "Layout",
+      "props": {
+        "variant": {
+          "enum": [
+            "side-by-side",
+            "2up",
+            "3up",
+            "1-3up",
+            "4up",
+            "1-4up",
+            "1-2-4up",
+            "2-4-6up"
+          ]
+        },
+        "gap": {
+          "enum": [
+            "sm",
+            "lg",
+            "none"
+          ]
+        },
+        "break": {
+          "enum": [
+            "faster",
+            "slower"
+          ]
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-grid-item",
+      "category": "Layout",
+      "props": {},
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-header",
+      "category": "Navigation",
+      "props": {
+        "isActive": {
+          "type": "boolean"
+        }
+      },
+      "slots": [
+        "default",
+        "top",
+        "bottom"
+      ]
+    },
+    {
+      "name": "cre8-heading",
+      "category": "Typography",
+      "props": {
+        "type": {
+          "enum": [
+            "display-default",
+            "display-small",
+            "headline-large",
+            "headline-default",
+            "headline-small",
+            "title-xlarge",
+            "title-large",
+            "title-default",
+            "title-small",
+            "label-large",
+            "label-default",
+            "label-small",
+            "meta-large",
+            "meta-default",
+            "meta-small"
+          ]
+        },
+        "inverted": {
+          "type": "boolean"
+        },
+        "tagVariant": {
+          "enum": [
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            "h5",
+            "h6"
+          ]
+        },
+        "brandColor": {
+          "type": "boolean"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-hero",
+      "category": "Layout",
+      "props": {
+        "align": {
+          "enum": [
+            "center",
+            "left",
+            "right",
+            "top-left",
+            "top-center",
+            "bottom-center",
+            "top-right",
+            "bottom-right"
+          ]
+        },
+        "imgSrc": {
+          "type": "string"
+        },
+        "imgAlt": {
+          "type": "string"
+        },
+        "hasOverlay": {
+          "type": "boolean"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-icon",
+      "category": "Media",
+      "props": {
+        "focusable": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "svg": {
+          "type": "string"
+        },
+        "iconUrl": {
+          "type": "string"
+        },
+        "iconTitle": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "name": "cre8-inline-alert",
+      "category": "Feedback",
+      "props": {
+        "variant": {
+          "enum": [
+            "subtle",
+            "transparent"
+          ]
+        },
+        "status": {
+          "enum": [
+            "error",
+            "info",
+            "neutral",
+            "warning",
+            "success",
+            "attention",
+            "help"
+          ]
+        },
+        "iconName": {
+          "type": "string"
+        },
+        "fullWidth": {
+          "type": "boolean"
+        },
+        "iconTitle": {
+          "type": "string"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-layout",
+      "category": "Layout",
+      "props": {
+        "variant": {
+          "type": "string"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-layout-container",
+      "category": "Layout",
+      "props": {
+        "fullHeight": {
+          "type": "boolean"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-layout-section",
+      "category": "Layout",
+      "props": {
+        "behavior": {
+          "type": "string"
+        },
+        "top": {
+          "type": "string"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-linelength-container",
+      "category": "Layout",
+      "props": {},
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-link",
+      "category": "Navigation",
+      "props": {
+        "href": {
+          "type": "string"
+        },
+        "rel": {
+          "type": "string"
+        },
+        "target": {
+          "enum": [
+            "_blank",
+            "_self",
+            "_parent",
+            "_top"
+          ]
+        },
+        "svg": {
+          "type": "string"
+        },
+        "size": {
+          "enum": [
+            "sm",
+            "lg"
+          ]
+        },
+        "inverted": {
+          "type": "boolean"
+        },
+        "iconName": {
+          "type": "string"
+        },
+        "iconRotateDegree": {
+          "type": "number"
+        },
+        "iconFlipDirection": {
+          "type": "string"
+        },
+        "iconPosition": {
+          "enum": [
+            "before",
+            "after"
+          ]
+        },
+        "ctaIcon": {
+          "type": "string"
+        },
+        "ctaLink": {
+          "type": "boolean"
+        },
+        "noUnderline": {
+          "type": "boolean"
+        }
+      },
+      "slots": [
+        "default",
+        "badge"
+      ]
+    },
+    {
+      "name": "cre8-link-list",
+      "category": "Navigation",
+      "props": {
+        "behavior": {
+          "enum": [
+            "horizontal",
+            "responsive"
+          ]
+        },
+        "inverted": {
+          "type": "boolean"
+        },
+        "size": {
+          "type": "string"
+        },
+        "spacing": {
+          "type": "string"
+        },
+        "variant": {
+          "enum": [
+            "secondary",
+            "display"
+          ]
+        },
+        "items": {
+          "type": "array"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-link-list-item",
+      "category": "Navigation",
+      "props": {
+        "text": {
+          "type": "string"
+        },
+        "href": {
+          "type": "string"
+        },
+        "isActive": {
+          "type": "boolean"
+        }
+      },
+      "slots": [
+        "default",
+        "itemBefore",
+        "itemAfter"
+      ]
+    },
+    {
+      "name": "cre8-list",
+      "category": "Data",
+      "props": {
+        "variant": {
+          "type": "string"
+        },
+        "spacing": {
+          "enum": [
+            "condensed",
+            "padded"
+          ]
+        },
+        "items": {
+          "type": "array"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-list-item",
+      "category": "Data",
+      "props": {},
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-loading-spinner",
+      "category": "Feedback",
+      "props": {
+        "determinate": {
+          "type": "boolean"
+        },
+        "inverse": {
+          "type": "boolean"
+        },
+        "neutral": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": "string"
+        },
+        "progress": {
+          "type": "number"
+        },
+        "size": {
+          "enum": [
+            "large",
+            "small"
+          ]
+        },
+        "buttonVariant": {
+          "enum": [
+            "primary",
+            "secondary",
+            "tertiary"
+          ]
+        }
+      }
+    },
+    {
+      "name": "cre8-logo",
+      "category": "Media",
+      "props": {
+        "href": {
+          "type": "string"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-main",
+      "category": "Layout",
+      "props": {
+        "fullHeight": {
+          "type": "boolean"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-modal",
+      "category": "Disclosure",
+      "props": {
+        "status": {
+          "enum": [
+            "error",
+            "info",
+            "warning",
+            "success",
+            "help"
+          ]
+        },
+        "isActive": {
+          "type": "boolean"
+        },
+        "utilityModalTitle": {
+          "type": "string"
+        },
+        "notDismissible": {
+          "type": "boolean"
+        },
+        "closeButtonText": {
+          "type": "string"
+        },
+        "closeButtonIcon": {
+          "type": "string"
+        },
+        "ariaLabel": {
+          "type": "string"
+        },
+        "mapStatusToIconModal": {
+          "type": "string"
+        }
+      },
+      "slots": [
+        "default",
+        "header",
+        "footer"
+      ]
+    },
+    {
+      "name": "cre8-multi-select",
+      "category": "Forms",
+      "props": {
+        "items": {
+          "type": "array"
+        },
+        "label": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "preselectedItems": {
+          "type": "array"
+        },
+        "fieldId": {
+          "type": "string"
+        },
+        "fieldNote": {
+          "type": "string"
+        },
+        "ariaDescribedBy": {
+          "type": "string"
+        },
+        "validationAriaDescribedBy": {
+          "type": "string"
+        },
+        "isError": {
+          "type": "boolean"
+        },
+        "errorNote": {
+          "type": "string"
+        },
+        "isSuccess": {
+          "type": "boolean"
+        },
+        "successNote": {
+          "type": "string"
+        },
+        "selectedTagItems": {
+          "type": "array"
+        },
+        "dropdownOpen": {
+          "type": "boolean"
+        }
+      },
+      "slots": [
+        "fieldNote"
+      ]
+    },
+    {
+      "name": "cre8-nav-container",
+      "category": "Navigation",
+      "props": {},
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-page-header",
+      "category": "Marketing",
+      "props": {
+        "heading": {
+          "type": "string"
+        }
+      },
+      "slots": [
+        "default",
+        "titleAfter"
+      ]
+    },
+    {
+      "name": "cre8-pagination",
+      "category": "Navigation",
+      "props": {
+        "display": {
+          "enum": [
+            "compact",
+            "icon-only",
+            "default"
+          ]
+        },
+        "totalResults": {
+          "type": "number"
+        },
+        "pageSize": {
+          "type": "number"
+        },
+        "visiblePages": {
+          "type": "number"
+        },
+        "hideLastAndFirstButtons": {
+          "type": "boolean"
+        },
+        "currentPage": {
+          "type": "number"
+        },
+        "elementDefinitions": {
+          "type": "string"
+        },
+        "windowWidth": {
+          "type": "number"
+        },
+        "buttons": {
+          "type": "string"
+        },
+        "maxVisiblePages": {
+          "type": "number"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-percent-bar",
+      "category": "Feedback",
+      "props": {
+        "value": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "disableActionLeft": {
+          "type": "boolean"
+        }
+      }
+    },
+    {
+      "name": "cre8-popover",
+      "category": "Disclosure",
+      "props": {
+        "heading": {
+          "type": "string"
+        },
+        "position": {
+          "enum": [
+            "top",
+            "left",
+            "right"
+          ]
+        },
+        "isVisibleOnScroll": {
+          "type": "boolean"
+        },
+        "isDynamic": {
+          "type": "boolean"
+        },
+        "isActiveDynamic": {
+          "type": "boolean"
+        },
+        "isActive": {
+          "type": "boolean"
+        },
+        "isRTL": {
+          "type": "boolean"
+        },
+        "handleOnClickOutside": {
+          "type": "string"
+        },
+        "removeActiveOnScroll": {
+          "type": "string"
+        },
+        "removeActive": {
+          "type": "string"
+        }
+      },
+      "slots": [
+        "default",
+        "trigger",
+        "header",
+        "footer"
+      ]
+    },
+    {
+      "name": "cre8-primary-nav",
+      "category": "Navigation",
+      "props": {
+        "inverted": {
+          "type": "boolean"
+        },
+        "behavior": {
+          "type": "string"
+        },
+        "navAriaLabel": {
+          "type": "string"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-primary-nav-item",
+      "category": "Navigation",
+      "props": {
+        "text": {
+          "type": "string"
+        },
+        "href": {
+          "type": "string"
+        },
+        "iconName": {
+          "type": "string"
+        },
+        "megaMenu": {
+          "type": "boolean"
+        },
+        "isActive": {
+          "type": "boolean"
+        }
+      },
+      "slots": [
+        "default",
+        "itemBefore",
+        "itemAfter"
+      ]
+    },
+    {
+      "name": "cre8-progress-meter",
+      "category": "Feedback",
+      "props": {
+        "status": {
+          "enum": [
+            "error",
+            "warning",
+            "success"
+          ]
+        },
+        "knockout": {
+          "type": "boolean"
+        },
+        "max": {
+          "type": "number"
+        },
+        "value": {
+          "type": "number"
+        },
+        "name": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "fieldId": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "name": "cre8-progress-steps",
+      "category": "Other",
+      "props": {
+        "steps": {
+          "type": "array"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-progress-steps-item",
+      "category": "Feedback",
+      "props": {
+        "state": {
+          "enum": [
+            "error",
+            "warning",
+            "complete",
+            "current",
+            "incomplete"
+          ]
+        },
+        "message": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "svg": {
+          "type": "string"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-radio-field",
+      "category": "Forms",
+      "props": {
+        "label": {
+          "type": "string"
+        },
+        "items": {
+          "type": "array"
+        },
+        "name": {
+          "type": "string"
+        },
+        "fieldNote": {
+          "type": "string"
+        },
+        "ariaDescribedBy": {
+          "type": "string"
+        },
+        "fieldNoteIconName": {
+          "type": "string"
+        },
+        "fieldNoteKnockout": {
+          "type": "boolean"
+        },
+        "isSuccess": {
+          "type": "boolean"
+        },
+        "isError": {
+          "type": "boolean"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-radio-field-item",
+      "category": "Forms",
+      "props": {
+        "checked": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "value": {
+          "type": "string"
+        },
+        "ariaDescribedBy": {
+          "type": "string"
+        },
+        "fieldId": {
+          "type": "string"
+        },
+        "fieldNote": {
+          "type": "string"
+        },
+        "fieldNoteIconName": {
+          "type": "string"
+        },
+        "fieldNoteKnockout": {
+          "type": "boolean"
+        },
+        "fieldNoteIsError": {
+          "type": "boolean"
+        },
+        "isError": {
+          "type": "boolean"
+        },
+        "isSuccess": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "name": "cre8-remove-tag",
+      "category": "Data",
+      "props": {
+        "text": {
+          "type": "string"
+        },
+        "color": {
+          "enum": [
+            "neutral",
+            "branded",
+            "neutral-hybrid"
+          ]
+        },
+        "shape": {
+          "enum": [
+            "round",
+            "square"
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    {
+      "name": "cre8-section",
+      "category": "Layout",
+      "props": {
+        "headline": {
+          "type": "string"
+        }
+      },
+      "slots": [
+        "default",
+        "header"
+      ]
+    },
+    {
+      "name": "cre8-select",
+      "category": "Forms",
+      "props": {
+        "items": {
+          "type": "array"
+        },
+        "label": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "value": {
+          "type": "string"
+        },
+        "fieldId": {
+          "type": "string"
+        },
+        "fieldNote": {
+          "type": "string"
+        },
+        "ariaDescribedBy": {
+          "type": "string"
+        },
+        "validationAriaDescribedBy": {
+          "type": "string"
+        },
+        "errorNote": {
+          "type": "string"
+        },
+        "successNote": {
+          "type": "string"
+        },
+        "isError": {
+          "type": "boolean"
+        },
+        "isSuccess": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "slots": [
+        "fieldNote"
+      ]
+    },
+    {
+      "name": "cre8-select-tile",
+      "category": "Forms",
+      "props": {
+        "variant": {
+          "enum": [
+            "bare",
+            "horizontal",
+            "horizontal-bare"
+          ]
+        },
+        "align": {
+          "type": "string"
+        },
+        "checked": {
+          "type": "boolean"
+        },
+        "type": {
+          "enum": [
+            "checkbox",
+            "radio"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "value": {
+          "type": "string"
+        },
+        "variantBreakToVertical": {
+          "enum": [
+            "sm",
+            "lg",
+            "none",
+            "md",
+            "sm-2",
+            "xl",
+            "xxl"
+          ]
+        },
+        "checkPosition": {
+          "enum": [
+            "none",
+            "left",
+            "right",
+            "top-right"
+          ]
+        },
+        "radioVariant": {
+          "enum": [
+            "dot",
+            "check"
+          ]
+        },
+        "fieldId": {
+          "type": "string"
+        },
+        "isError": {
+          "type": "boolean"
+        },
+        "isSuccess": {
+          "type": "boolean"
+        },
+        "shadowRootOptions": {
+          "type": "string"
+        },
+        "defaultChecked": {
+          "type": "boolean"
+        }
+      },
+      "slots": [
+        "default",
+        "header",
+        "footer",
+        "title",
+        "body"
+      ]
+    },
+    {
+      "name": "cre8-select-tile-list",
+      "category": "Forms",
+      "props": {
+        "variant": {
+          "enum": [
+            "columns",
+            "rows"
+          ]
+        },
+        "label": {
+          "type": "string"
+        },
+        "fieldNote": {
+          "type": "string"
+        },
+        "ariaDescribedBy": {
+          "type": "string"
+        },
+        "fieldNoteIconName": {
+          "type": "string"
+        },
+        "fieldNoteKnockout": {
+          "type": "boolean"
+        },
+        "fieldNoteIsSuccess": {
+          "type": "boolean"
+        },
+        "fieldNoteIsError": {
+          "type": "boolean"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-skeleton-loader",
+      "category": "Feedback",
+      "props": {
+        "variant": {
+          "enum": [
+            "rectangle",
+            "square",
+            "circle"
+          ]
+        },
+        "height": {
+          "type": "string"
+        },
+        "width": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "name": "cre8-split-button",
+      "category": "Actions",
+      "props": {
+        "disabled": {
+          "type": "boolean"
+        },
+        "size": {
+          "enum": [
+            "sm",
+            "lg"
+          ]
+        },
+        "buttonText": {
+          "type": "string"
+        },
+        "dropdownOpen": {
+          "type": "boolean"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-submenu",
+      "category": "Disclosure",
+      "props": {},
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-submenu-item",
+      "category": "Disclosure",
+      "props": {
+        "href": {
+          "type": "string"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-tab",
+      "category": "Navigation",
+      "props": {
+        "size": {
+          "type": "string"
+        },
+        "index": {
+          "type": "number"
+        },
+        "isActive": {
+          "type": "boolean"
+        },
+        "ariaLabelledBy": {
+          "type": "string"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-tab-panel",
+      "category": "Navigation",
+      "props": {
+        "index": {
+          "type": "number"
+        },
+        "skipFocusOnPanel": {
+          "type": "boolean"
+        },
+        "isActive": {
+          "type": "boolean"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-table",
+      "category": "Data",
+      "props": {
+        "columns": {
+          "type": "array"
+        },
+        "rows": {
+          "type": "array"
+        },
+        "caption": {
+          "type": "string"
+        },
+        "behavior": {
+          "type": "string"
+        },
+        "variant": {
+          "type": "string"
+        },
+        "isHoverable": {
+          "type": "boolean"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-table-body",
+      "category": "Data",
+      "props": {},
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-table-cell",
+      "category": "Data",
+      "props": {
+        "colspan": {
+          "type": "number"
+        },
+        "variant": {
+          "type": "string"
+        },
+        "dataHeader": {
+          "type": "string"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-table-header",
+      "category": "Data",
+      "props": {},
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-table-header-cell",
+      "category": "Data",
+      "props": {
+        "colspan": {
+          "type": "number"
+        },
+        "width": {
+          "type": "string"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-table-object",
+      "category": "Data",
+      "props": {},
+      "slots": [
+        "default",
+        "header",
+        "footer"
+      ]
+    },
+    {
+      "name": "cre8-table-row",
+      "category": "Data",
+      "props": {
+        "variant": {
+          "type": "string"
+        },
+        "isExpanded": {
+          "type": "boolean"
+        },
+        "isExpandable": {
+          "type": "boolean"
+        },
+        "expandedButtonText": {
+          "type": "string"
+        },
+        "collapsedButtonText": {
+          "type": "string"
+        }
+      },
+      "slots": [
+        "default",
+        "expandableContent"
+      ]
+    },
+    {
+      "name": "cre8-tabs",
+      "category": "Navigation",
+      "props": {
+        "size": {
+          "type": "string"
+        },
+        "items": {
+          "type": "array"
+        },
+        "fullWidth": {
+          "type": "boolean"
+        },
+        "activeIndex": {
+          "type": "number"
+        },
+        "isStart": {
+          "type": "boolean"
+        },
+        "isEnd": {
+          "type": "boolean"
+        },
+        "activeTab": {
+          "type": "string"
+        },
+        "isRTL": {
+          "type": "boolean"
+        },
+        "handleScroll": {
+          "type": "string"
+        },
+        "handleResize": {
+          "type": "string"
+        },
+        "setIsStart": {
+          "type": "string"
+        },
+        "setIsEnd": {
+          "type": "string"
+        },
+        "emitEvent": {
+          "type": "string"
+        },
+        "tabId": {
+          "type": "string"
+        }
+      },
+      "slots": [
+        "default",
+        "panel"
+      ]
+    },
+    {
+      "name": "cre8-tag",
+      "category": "Data",
+      "props": {
+        "text": {
+          "type": "string"
+        },
+        "variant": {
+          "enum": [
+            "neutral",
+            "branded",
+            "neutral-hybrid"
+          ]
+        },
+        "shape": {
+          "enum": [
+            "square",
+            "round"
+          ]
+        },
+        "type": {
+          "enum": [
+            "checkbox",
+            "radio"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "value": {
+          "type": "string"
+        },
+        "isDisabled": {
+          "type": "boolean"
+        },
+        "isSelected": {
+          "type": "boolean"
+        },
+        "fieldId": {
+          "type": "string"
+        },
+        "isError": {
+          "type": "boolean"
+        },
+        "isSuccess": {
+          "type": "boolean"
+        }
+      }
+    },
+    {
+      "name": "cre8-tag-list",
+      "category": "Data",
+      "props": {
+        "label": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array"
+        },
+        "fieldId": {
+          "type": "string"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-tertiary-nav",
+      "category": "Navigation",
+      "props": {
+        "fullWidth": {
+          "type": "boolean"
+        },
+        "navAriaLabel": {
+          "type": "string"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-tertiary-nav-item",
+      "category": "Navigation",
+      "props": {
+        "href": {
+          "type": "string"
+        },
+        "isCurrent": {
+          "type": "boolean"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-text-link",
+      "category": "Typography",
+      "props": {
+        "href": {
+          "type": "string"
+        },
+        "variant": {
+          "enum": [
+            "secondary",
+            "display"
+          ]
+        },
+        "size": {
+          "type": "string"
+        },
+        "inverted": {
+          "type": "boolean"
+        }
+      },
+      "slots": [
+        "default",
+        "linkAfter"
+      ]
+    },
+    {
+      "name": "cre8-text-passage",
+      "category": "Typography",
+      "props": {
+        "inverted": {
+          "type": "boolean"
+        },
+        "size": {
+          "enum": [
+            "large",
+            "small",
+            "default"
+          ]
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-tooltip",
+      "category": "Disclosure",
+      "props": {
+        "position": {
+          "enum": [
+            "default",
+            "top",
+            "left",
+            "right"
+          ]
+        },
+        "knockout": {
+          "type": "boolean"
+        },
+        "svg": {
+          "type": "string"
+        },
+        "isDynamic": {
+          "type": "boolean"
+        },
+        "isActiveDynamic": {
+          "type": "boolean"
+        },
+        "isActive": {
+          "type": "boolean"
+        },
+        "ariaDescribes": {
+          "type": "string"
+        },
+        "iconRotateDegree": {
+          "type": "number"
+        },
+        "iconFlipDirection": {
+          "type": "string"
+        },
+        "isRTL": {
+          "type": "boolean"
+        },
+        "removeActive": {
+          "type": "string"
+        }
+      },
+      "slots": [
+        "default",
+        "trigger"
+      ]
+    },
+    {
+      "name": "cre8-utility-nav",
+      "category": "Navigation",
+      "props": {
+        "inverted": {
+          "type": "boolean"
+        },
+        "navAriaLabel": {
+          "type": "string"
+        }
+      },
+      "acceptsChildren": true
+    },
+    {
+      "name": "cre8-utility-nav-item",
+      "category": "Navigation",
+      "props": {
+        "href": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        },
+        "hideText": {
+          "type": "boolean"
+        },
+        "iconName": {
+          "type": "string"
+        },
+        "iconPosition": {
+          "enum": [
+            "before",
+            "after"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/packages/cre8-wc/a2ui/generate-catalog.mjs
+++ b/packages/cre8-wc/a2ui/generate-catalog.mjs
@@ -6,6 +6,7 @@ import { dirname, resolve } from 'node:path';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const manifestPath = resolve(__dirname, '..', 'mcp-manifest.json');
 const outPath = resolve(__dirname, 'catalog.json');
+const compactOutPath = resolve(__dirname, 'catalog.compact.json');
 
 const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
 
@@ -356,4 +357,53 @@ const catalog = {
 writeFileSync(outPath, JSON.stringify(catalog, null, 2) + '\n');
 console.log(
   `Wrote ${outPath} (${manifest.components.length} components, ${(JSON.stringify(catalog).length / 1024).toFixed(1)} KB)`
+);
+
+// The compact projection: the minimum a model needs to emit valid A2UI. Prose is
+// ~90% of the catalog's bytes and none of its decoding constraint, so dropping it
+// is what lets a small-context model see the design system at all.
+//
+// Emitted here rather than in a separate script so it cannot drift from the
+// catalog it projects.
+function compactProps(propsNode) {
+  const out = {};
+  for (const [name, spec] of Object.entries(propsNode?.properties ?? {})) {
+    out[name] = spec.enum ? { enum: spec.enum } : { type: spec.type ?? 'string' };
+  }
+  return out;
+}
+
+const compactComponents = Object.entries(components)
+  .map(([name, def]) => {
+    const props = def.properties ?? {};
+    const entry = { name, category: def['x-category'] ?? 'Uncategorized' };
+
+    if (props.props) {
+      entry.props = compactProps(props.props);
+      if (props.props.required?.length) entry.required = props.props.required;
+    }
+    // Containment is expressed two ways and consumers need both: `children` for
+    // plain containers, `slots` for named regions. Dropping either makes a
+    // container look like a leaf.
+    if (props.children) entry.acceptsChildren = true;
+    if (props.slots) entry.slots = Object.keys(props.slots.properties ?? {});
+    return entry;
+  })
+  .sort((a, b) => a.name.localeCompare(b.name));
+
+const compact = {
+  contractVersion: 1,
+  sourceCatalog: catalog.$id,
+  libraryVersion: manifest.version,
+  componentCount: compactComponents.length,
+  components: compactComponents,
+};
+
+writeFileSync(compactOutPath, JSON.stringify(compact, null, 2) + '\n');
+
+const fullBytes = JSON.stringify(components).length;
+const compactBytes = JSON.stringify(compact).length;
+console.log(
+  `Wrote ${compactOutPath} (${compactComponents.length} components, ` +
+    `${(compactBytes / 1024).toFixed(1)} KB, ${(fullBytes / compactBytes).toFixed(1)}x smaller)`
 );

--- a/packages/cre8-wc/package.json
+++ b/packages/cre8-wc/package.json
@@ -94,6 +94,7 @@
       "types": "./a2ui/index.d.ts"
     },
     "./a2ui/catalog.json": "./a2ui/catalog.json",
+    "./a2ui/catalog.compact.json": "./a2ui/catalog.compact.json",
     "./a2ui/catalog-kg.json": "./a2ui/catalog-kg.json",
     "./a2ui/*": {
       "import": "./a2ui/*",


### PR DESCRIPTION
## Description

Adds the two pieces that let a caller fetch a **slice** of the A2UI catalog sized to its context, instead of taking all of it.

The full catalog is ~43k tokens. That is more than a small-context model can hold at all, and more than a cloud model should pay for on every request.

**1. Compact projection (`cre8-wc`).** `generate-catalog.mjs` now emits `catalog.compact.json` alongside `catalog.json` from the same run, so the two cannot drift. The projection keeps what a model needs to emit valid A2UI — prop names, enum choices, required lists, slot names, containment — and drops prose, which is ~90% of the bytes and none of the decoding constraint.

| Artifact | Size |
| --- | ---: |
| `catalog.json` | 174.3 KB |
| `catalog.compact.json` | 22.6 KB (7.5× smaller) |

**2. `GET /a2ui/context` (`cre8-mcp`).** Serves a slice sized to the caller:

| Param | Purpose |
| --- | --- |
| `names` / `categories` | selection |
| `projection` | `compact` (default) or `full` |
| `budget` | token ceiling |
| `pinned` | components admitted before the budget is spent elsewhere |

```
GET /a2ui/context?categories=Actions&budget=800&pinned=cre8-button
→ cre8-button, cre8-button-group, cre8-danger-button, cre8-split-button
  561 tokens, truncated: false
```

Both changes are **purely additive**. No existing route, output, or behaviour is altered.

## Scope

- [ ] __Bug fix__ - non-breaking change which fixes an issue
- [x] __New feature__ - non-breaking change which adds functionality
- [ ] __Breaking change__ - fix or feature that would cause existing functionality to change

## Quality Checks

- [ ] Resolves an issue - Github Issue and/or Jira story created; No duplicates
- [ ] Follows branch name convention
- [ ] Version updated per [Semantic Versioning](https://semver.org) standard, if needed
- [x] Documentation - CSS comments, JS comments, Doc blocks
- [x] Did you use CSS Logical Properties for your CSS? — n/a, no CSS in this change
- [x] Create React wrapper — n/a, no new web components
- [x] Storybook WC, React — n/a, no component changes
- [x] Performed a self-guided visual regression test for each respective brand — n/a, no rendered output changes
- [x] Did you add custom events in the WC? — n/a
- [ ] Updated CHANGELOG
- [x] I've performed a self-review of my code
- [x] My code passes linting and code quality checks
- [x] New and existing tests pass with my code changes
- [x] My code builds without generating new errors/warnings

## Additional Information

### Two decisions worth reviewing

**Whole components are dropped, never truncated.** A half-serialised prop list would teach a model a component signature that does not exist. Over-budget requests return `truncated: true` and `droppedCount` so the caller can surface it — budget starvation is the one failure here that degrades quality invisibly rather than erroring.

**`pinned` exists because of a measured bug.** Filling a budget smallest-first starves exactly the components worth keeping: definition size tracks prop count, so the most capable component in a category is the first casualty. A 1200-token budget over `Forms,Actions,Typography` dropped `cre8-button` (249t) and `cre8-field` (206t), and an on-device model then substituted `cre8-checkbox-field` for a password input. Pinning rescues them. The regression test asserts **both** halves — that the starvation reproduces unpinned, and that pinning fixes it — so the guard cannot silently stop testing anything.

**Containment is recorded two ways** (`acceptsChildren` for plain containers, `slots` for named regions) because consumers need both. An earlier projection kept only `slots`, which made 47 of 85 containers look like leaves.

### Test results

| Suite | Result |
| --- | --- |
| `pnpm test:mcp` | 51 + 4 + **12 new** passed, 0 failed |
| `pnpm test:a2ui` | 35 + 18 passed, render audit ok |
| `pnpm kb:check` | 4/4 checks ok, no new drift |

The 12 new tests cover projection fidelity, budget behaviour, the pinning regression, category/name selection, error cases, and that the route sits behind the existing bearer gate.

### Notes for the reviewer

- `packages/cre8-mcp/dist/` is tracked in this repo, so the compiled output is included. It is plain `tsc` output from the committed sources.
- `catalog.json` is unchanged — regenerating it on this branch produced a byte-identical file, confirming the compact artifact is derived from the same manifest and introduces no incidental version churn.
- CHANGELOG is not updated; happy to add an entry if you'd like this to carry one.

### Context

This is steps 0–1 of a larger migration toward a BYOK harness where the client owns the model call and the server is a key-free knowledge plane. Both steps were chosen to be independently shippable and behaviour-preserving — nothing here commits the repo to the rest of that direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
