### PR TITLE
Show the model the whole catalog, and validate event names

### DIFF
--- a/packages/cre8-studio/src/lib/catalog-index.ts
+++ b/packages/cre8-studio/src/lib/catalog-index.ts
@@ -1,61 +1,78 @@
 import catalog from "@tmorrow/cre8-wc/a2ui/catalog.json" with { type: "json" };
+import compactCatalog from "@tmorrow/cre8-wc/a2ui/catalog.compact.json" with { type: "json" };
 
 type CatalogJson = {
   $defs: {
-    components: Record<
-      string,
-      {
-        description?: string;
-        properties?: {
-          props?: {
-            properties?: Record<string, { description?: string; enum?: unknown[]; const?: unknown; type?: unknown }>;
-          };
-          children?: unknown;
-          slots?: { properties?: Record<string, { description?: string }> };
-          events?: { properties?: Record<string, { description?: string }> };
-        };
-      }
-    >;
+    components: Record<string, { description?: string }>;
   };
 };
 
+type CompactCatalogJson = {
+  components: Array<{
+    name: string;
+    category: string;
+    props?: Record<string, { type?: string | string[]; enum?: string[] }>;
+    required?: string[];
+    acceptsChildren?: boolean;
+    slots?: string[];
+    events?: string[];
+  }>;
+};
+
+/**
+ * The component list the model is shown.
+ *
+ * Built from the compact projection rather than by re-summarising the full
+ * catalog. The previous implementation truncated props to the first 8 and enums
+ * to the first 4, which hid 29% of props and 34% of enum values — and enum
+ * values are the decoding constraint, so a hidden one is a value the model
+ * cannot choose. `cre8-button.size` and `cre8-button.type` were entirely
+ * invisible, meaning the model could not size a button or make a submit button.
+ *
+ * Descriptions still come from the full catalog: the compact projection drops
+ * prose deliberately, but a one-line description is what makes a component
+ * findable, and it is cheap.
+ */
 export function buildCatalogSummary(): string {
-  const c = catalog as unknown as CatalogJson;
-  const entries = Object.entries(c.$defs?.components ?? {});
+  const descriptions = (catalog as unknown as CatalogJson).$defs?.components ?? {};
+  const { components } = compactCatalog as unknown as CompactCatalogJson;
   const lines: string[] = [];
-  for (const [name, def] of entries) {
-    const desc = (def.description ?? "").split("\n")[0].trim().slice(0, 120);
-    const props = def.properties?.props?.properties ?? {};
-    const propKeys = Object.keys(props);
-    const propSummary = propKeys
-      .slice(0, 8)
-      .map((k) => {
-        const p = props[k] ?? {};
-        if (Array.isArray(p.enum)) return `${k}:${p.enum.slice(0, 4).join("|")}`;
-        if (p.const !== undefined) return `${k}=${JSON.stringify(p.const)}`;
-        return k;
+
+  for (const component of components) {
+    const desc = (descriptions[component.name]?.description ?? "")
+      .split("\n")[0]
+      .trim()
+      .slice(0, 120);
+
+    const props = component.props ?? {};
+    const required = new Set(component.required ?? []);
+    const propSummary = Object.keys(props)
+      .map((key) => {
+        const spec = props[key] ?? {};
+        const marker = required.has(key) ? "*" : "";
+        // Enum values are listed in full — truncating them is what made valid
+        // values unreachable.
+        if (spec.enum?.length) return `${key}${marker}:${spec.enum.join("|")}`;
+        return `${key}${marker}`;
       })
       .join(", ");
-    const slots = Object.keys(def.properties?.slots?.properties ?? {});
-    const events = Object.keys(def.properties?.events?.properties ?? {});
-    // Post-refactor the default content slot is explicit: a component either has
-    // a top-level `children` array OR a named `slots.default` — never both, and
-    // the two are NOT interchangeable. Spell this out so the model never puts
-    // body content in `children` for a slot-based component.
-    const acceptsChildren = !!def.properties?.children;
 
-    let line = `- ${name}`;
+    let line = `- ${component.name}`;
     if (desc) line += ` — ${desc}`;
     if (propSummary) line += `\n    props: ${propSummary}`;
-    if (acceptsChildren) {
+    // A component takes either a top-level `children` array OR a named
+    // `slots.default` — never both, and the two are NOT interchangeable. Spell
+    // it out so the model never puts body content in the wrong one.
+    if (component.acceptsChildren) {
       line += `\n    content: children[]`;
-    } else if (slots.includes("default")) {
+    } else if (component.slots?.includes("default")) {
       line += `\n    content: slots.default  (NOT children)`;
     }
-    if (slots.length) line += `\n    slots: ${slots.join(", ")}`;
-    if (events.length) line += `\n    events: ${events.join(", ")}`;
+    if (component.slots?.length) line += `\n    slots: ${component.slots.join(", ")}`;
+    if (component.events?.length) line += `\n    events: ${component.events.join(", ")}`;
     lines.push(line);
   }
+
   return lines.join("\n");
 }
 

--- a/packages/cre8-wc/a2ui/catalog.compact.json
+++ b/packages/cre8-wc/a2ui/catalog.compact.json
@@ -393,7 +393,12 @@
         "colors": {
           "type": "array"
         }
-      }
+      },
+      "events": [
+        "chart-click",
+        "chart-hover",
+        "chart-ready"
+      ]
     },
     {
       "name": "cre8-checkbox-field",
@@ -490,6 +495,9 @@
       },
       "slots": [
         "fieldNote"
+      ],
+      "events": [
+        "change"
       ]
     },
     {
@@ -739,7 +747,10 @@
           "type": "string"
         }
       },
-      "acceptsChildren": true
+      "acceptsChildren": true,
+      "events": [
+        "dropdown-item-select"
+      ]
     },
     {
       "name": "cre8-feature",
@@ -1362,6 +1373,9 @@
         "default",
         "header",
         "footer"
+      ],
+      "events": [
+        "modal-close"
       ]
     },
     {
@@ -1413,6 +1427,9 @@
       },
       "slots": [
         "fieldNote"
+      ],
+      "events": [
+        "multi-select-change"
       ]
     },
     {
@@ -1473,7 +1490,10 @@
           "type": "number"
         }
       },
-      "acceptsChildren": true
+      "acceptsChildren": true,
+      "events": [
+        "pagination-change"
+      ]
     },
     {
       "name": "cre8-percent-bar",
@@ -1488,7 +1508,10 @@
         "disableActionLeft": {
           "type": "boolean"
         }
-      }
+      },
+      "events": [
+        "percent-bar-left-action-click"
+      ]
     },
     {
       "name": "cre8-popover",
@@ -1534,6 +1557,10 @@
         "trigger",
         "header",
         "footer"
+      ],
+      "events": [
+        "popover-open",
+        "popover-close"
       ]
     },
     {
@@ -1752,7 +1779,10 @@
         "disabled": {
           "type": "boolean"
         }
-      }
+      },
+      "events": [
+        "remove-tag-click"
+      ]
     },
     {
       "name": "cre8-section",
@@ -1819,6 +1849,9 @@
       },
       "slots": [
         "fieldNote"
+      ],
+      "events": [
+        "change"
       ]
     },
     {
@@ -1903,6 +1936,10 @@
         "footer",
         "title",
         "body"
+      ],
+      "events": [
+        "change",
+        "input"
       ]
     },
     {
@@ -1978,7 +2015,11 @@
           "type": "boolean"
         }
       },
-      "acceptsChildren": true
+      "acceptsChildren": true,
+      "events": [
+        "split-button-text-click",
+        "split-button-dropdown-click"
+      ]
     },
     {
       "name": "cre8-submenu",
@@ -2013,7 +2054,10 @@
           "type": "string"
         }
       },
-      "acceptsChildren": true
+      "acceptsChildren": true,
+      "events": [
+        "tab-select"
+      ]
     },
     {
       "name": "cre8-tab-panel",
@@ -2182,6 +2226,9 @@
       "slots": [
         "default",
         "panel"
+      ],
+      "events": [
+        "tab-change"
       ]
     },
     {
@@ -2237,7 +2284,10 @@
         "isSuccess": {
           "type": "boolean"
         }
-      }
+      },
+      "events": [
+        "change"
+      ]
     },
     {
       "name": "cre8-tag-list",
@@ -2369,6 +2419,10 @@
       "slots": [
         "default",
         "trigger"
+      ],
+      "events": [
+        "tooltip-open",
+        "tooltip-close"
       ]
     },
     {

--- a/packages/cre8-wc/a2ui/generate-catalog.mjs
+++ b/packages/cre8-wc/a2ui/generate-catalog.mjs
@@ -387,6 +387,11 @@ const compactComponents = Object.entries(components)
     // container look like a leaf.
     if (props.children) entry.acceptsChildren = true;
     if (props.slots) entry.slots = Object.keys(props.slots.properties ?? {});
+    // Events live under `x-events`, not under `properties`, which makes them easy
+    // to miss — the studio's hand-rolled summary looked for them in the wrong
+    // place and so showed the model none of the 22 events the library emits.
+    const events = Object.keys(def['x-events'] ?? {});
+    if (events.length) entry.events = events;
     return entry;
   })
   .sort((a, b) => a.name.localeCompare(b.name));

--- a/packages/cre8-wc/a2ui/registry.ts
+++ b/packages/cre8-wc/a2ui/registry.ts
@@ -100,6 +100,30 @@ function describeType(v: unknown): string {
   return typeof v;
 }
 
+/**
+ * Native DOM events, bindable on any component.
+ *
+ * A component's `@fires` tags describe only what it dispatches itself, so the
+ * catalog can never list these — but `addEventListener` handles them on every
+ * element, and binding `click` to a button is the single most common thing an
+ * agent does. Kept deliberately narrow: the point of validating event names is
+ * to catch invented ones, so this is the set that genuinely fires, not every
+ * event name in the HTML spec.
+ */
+const NATIVE_DOM_EVENTS = new Set([
+  'click', 'dblclick', 'contextmenu',
+  'mousedown', 'mouseup', 'mouseenter', 'mouseleave', 'mouseover', 'mouseout', 'mousemove',
+  'pointerdown', 'pointerup', 'pointerenter', 'pointerleave',
+  'touchstart', 'touchend', 'touchmove', 'touchcancel',
+  'keydown', 'keyup', 'keypress',
+  'focus', 'blur', 'focusin', 'focusout',
+  'input', 'change', 'submit', 'reset', 'invalid', 'select',
+  'scroll', 'wheel', 'resize',
+  'copy', 'cut', 'paste',
+  'drag', 'dragstart', 'dragend', 'dragenter', 'dragleave', 'dragover', 'drop',
+  'load', 'error',
+]);
+
 export function validateSpec(spec: unknown, catalog: RegisteredCatalog, path = '$'): asserts spec is ComponentSpec {
   if (!spec || typeof spec !== 'object') {
     throw new Error(`${path}: spec must be an object`);
@@ -147,7 +171,25 @@ export function validateSpec(spec: unknown, catalog: RegisteredCatalog, path = '
     if (!s.events || typeof s.events !== 'object' || Array.isArray(s.events)) {
       throw new Error(`${path}.events: must be an object`);
     }
+    // Custom event *names* are checked against the catalog, the same way props
+    // and slots are. Previously only the binding shape was validated, so an
+    // invented event bound cleanly and then silently never fired — the worst
+    // failure mode available, since the UI renders and simply does nothing.
+    //
+    // Native DOM events are always allowed: `addEventListener` handles them on
+    // any element, and `@fires` documents only what a component dispatches
+    // itself. `click` on a button is legitimate and undocumented by design.
+    const declaredEvents = new Set(Object.keys(def['x-events'] ?? {}));
     for (const [evtName, binding] of Object.entries(s.events as Record<string, unknown>)) {
+      if (!NATIVE_DOM_EVENTS.has(evtName) && !declaredEvents.has(evtName)) {
+        const available = [...declaredEvents].sort().join(', ');
+        throw new Error(
+          `${path}.events.${evtName}: not a declared event on ${s.component}. ` +
+            (available
+              ? `Custom events available: ${available}`
+              : `${s.component} declares no custom events`)
+        );
+      }
       if (typeof binding === 'string') continue;
       if (!binding || typeof binding !== 'object') {
         throw new Error(`${path}.events.${evtName}: must be a string or { handler } object`);

--- a/packages/cre8-wc/a2ui/smoke-test.mjs
+++ b/packages/cre8-wc/a2ui/smoke-test.mjs
@@ -73,9 +73,43 @@ try {
   console.log('slot reject:', e.message);
 }
 
+// An invented custom event used to bind cleanly and then never fire — the UI
+// renders and silently does nothing, which is worse than an error.
+const badEvent = { component: 'cre8-modal', events: { 'totally-made-up': 'x' } };
+try {
+  validateSpec(badEvent, cat);
+  console.error('FAIL: expected rejection of undeclared event');
+  process.exit(1);
+} catch (e) {
+  console.log('event reject:', e.message);
+}
+
+// Binding a real event to the wrong component is the same failure wearing a
+// disguise: the name exists in the library, just not on this component.
+const misattributed = { component: 'cre8-button', events: { 'modal-close': 'x' } };
+try {
+  validateSpec(misattributed, cat);
+  console.error('FAIL: expected rejection of an event from another component');
+  process.exit(1);
+} catch (e) {
+  console.log('misattributed event reject:', e.message);
+}
+
+// Native DOM events stay bindable on anything — `@fires` documents only what a
+// component dispatches itself, so the catalog can never list `click`.
+for (const native of ['click', 'input', 'submit', 'keydown', 'focus']) {
+  validateSpec({ component: 'cre8-button', events: { [native]: 'h' } }, cat);
+}
+console.log('native events accepted on an undocumented component: ok');
+
+// Binds one native event and one custom event, on the component that actually
+// dispatches the custom one. It used to bind `split-button-text-click` to a
+// plain `cre8-button`, which no `cre8-button` ever fires — a binding that
+// renders cleanly and then silently does nothing. Event-name validation now
+// rejects that, so the example has to be a real pairing.
 const eventSpec = {
-  component: 'cre8-button',
-  props: { text: 'Save', variant: 'primary' },
+  component: 'cre8-split-button',
+  props: { buttonText: 'Save' },
   events: {
     click: { handler: 'save-record', stopPropagation: true },
     'split-button-text-click': 'emit-telemetry',


### PR DESCRIPTION
## Description

> **Stacked on #31**, which is stacked on #30. Base is `claude/cre8-agent-core-extraction`, so this diff shows only the coverage work. Merge #30 → #31 → this.
>
> ⚠️ **Unlike the two beneath it, this PR changes behaviour** — the system prompt differs and the validator is stricter. Worth a closer read than a refactor.

The studio built its own summary of the catalog for the system prompt, and truncated it: props sliced to the first 8, enum values to the first 4. Enum values are the *decoding constraint* — a hidden one is a value the model cannot choose.

`cre8-button` showed 8 of its 27 props. `size` (`sm|lg|md`) and `type` (`button|submit|reset`) were **entirely invisible** — so the model could not size a button or make a submit button, on the most-used component in the library.

The summary now builds from the compact projection with no truncation anywhere:

| | Before | After |
| --- | ---: | ---: |
| Props visible | 343 / 482 — 71.2% | **482 / 482** |
| Enum values visible | 148 / 225 — 65.8% | **225 / 225** |
| Events visible | 0 / 22 — 0% | **22 / 22** |
| Catalog block | ~4,393 tokens | **~4,314 tokens** |

It is **smaller**. Dropping prose more than pays for the restored props, enums and events, so the missing third of the design system cost nothing to put back. Descriptions still come from the full catalog — a one-line description is what makes a component findable, and it is cheap.

## Two bugs found while building it

**1. Event names were never validated.** Props and slots were both checked for membership; events were only checked for binding *shape*. An invented event bound cleanly, rendered fine, and then silently never fired — worse than an error, because nothing surfaces at all.

```
cre8-heading  + events: { nope: 'x' }             → was: ok    now: rejected
cre8-modal    + events: { 'totally-made-up': 'x' } → was: ok    now: rejected
cre8-modal    + props:  { notAProp: 1 }            → was: rejected (correct all along)
```

Event names are now checked exactly the way props and slots are.

**Native DOM events stay bindable on anything.** `@fires` documents only what a component dispatches itself, so the catalog can never list `click` — and `addEventListener` handles it on every element regardless. My first version of this check rejected `click`; the test suite caught it. There is now a narrow `NATIVE_DOM_EVENTS` allowlist and tests asserting `click`/`input`/`submit`/`keydown`/`focus` remain bindable on a component declaring no custom events.

**2. The smoke test encoded a wrong example.** It bound `split-button-text-click` to a plain `cre8-button`, but only `cre8-split-button` dispatches it (`split-button.ts:77`) — precisely the dead binding this validation exists to catch. Repointed at the component that actually fires it, preserving what the test asserts.

Events were invisible in the first place because they live under `x-events`, not under `properties`, and the old summary looked in the wrong place. They are now carried through the compact projection.

## Scope

- [x] __Bug fix__ - non-breaking change which fixes an issue
- [x] __New feature__ - non-breaking change which adds functionality
- [ ] __Breaking change__ - fix or feature that would cause existing functionality to change

Not marked breaking: the validator is stricter, but `kb:check` reports **0 event bindings** across all documented examples, and no shipped example binds an undeclared event. A consumer who had bound a non-firing event would now get an error instead of silence — which is the point.

## Quality Checks

- [ ] Resolves an issue - Github Issue and/or Jira story created; No duplicates
- [ ] Follows branch name convention
- [ ] Version updated per [Semantic Versioning](https://semver.org) standard, if needed
- [x] Documentation - CSS comments, JS comments, Doc blocks
- [x] Did you use CSS Logical Properties for your CSS? — n/a, no CSS
- [x] Create React wrapper — n/a, no new web components
- [x] Storybook WC, React — n/a, no component changes
- [x] Performed a self-guided visual regression test for each respective brand — n/a, no rendered output changes
- [x] Did you add custom events in the WC? — n/a, no new events; this validates existing ones
- [ ] Updated CHANGELOG
- [x] I've performed a self-review of my code
- [x] My code passes linting and code quality checks
- [x] New and existing tests pass with my code changes
- [x] My code builds without generating new errors/warnings

## Verification

Run **in this branch's own checkout**, not inferred from another tree:

| Check | Result |
| --- | --- |
| `pnpm test` (cre8-wc) | 58 suites, **413 tests** passed |
| `pnpm test:a2ui` | PASS — +3 new event cases |
| `pnpm test:mcp` | PASS |
| `pnpm test:agent` | PASS |
| studio `tsc --noEmit` | exit 0 |
| studio production build | ✓ compiled successfully |

New test cases: undeclared event rejected, event-from-another-component rejected, and native events accepted on a component declaring none.

### One known check failure, pre-existing and environmental

`pnpm kb:check` fails 3 rows, all of the form *"source file not found; cannot verify"*, for `.claude/marketplaces/tmorrow_ai/cre8/skills/cre8-a2ui-react/SKILL.md`. That path is **untracked**, so it is absent from any fresh checkout — the check passes only on a machine where the plugin cache happens to exist. Unrelated to this change; the other 3 kb tools pass, including the A2UI example validator.

## Notes for the reviewer

- **This PR deliberately excludes the text-children schema fix** (`$defs/Child`) that is sitting uncommitted in the working tree from a parallel session. It touches the same two files, so I regenerated the catalog here without it and verified the only delta between the two trees is that fix plus a version stamp. It should land as its own PR.
- `catalog.json` is unchanged by this PR — events flow only into `catalog.compact.json`.
- CHANGELOG not updated; happy to add an entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
