### PR TITLE
Give the knowledge plane per-tenant access

### DIFF
--- a/packages/cre8-mcp/dist/app.d.ts
+++ b/packages/cre8-mcp/dist/app.d.ts
@@ -10,10 +10,15 @@
  * binding a port.
  */
 import { Hono } from 'hono';
+import { RateLimiter, type TenantConfig } from './tenants.js';
 export interface AppOptions {
     /** Defaults to $PORT, used only to build viewer URLs. */
     port?: number;
     /** Overrides $CRE8_MCP_TOKEN. Pass an empty string to disable the gate. */
     token?: string;
+    /** Overrides $CRE8_MCP_TENANTS. Injected by tests. */
+    tenants?: TenantConfig;
+    /** Injected by tests so limits can be exercised without waiting a minute. */
+    rateLimiter?: RateLimiter;
 }
 export declare function createApp(options?: AppOptions): Hono;

--- a/packages/cre8-mcp/dist/app.js
+++ b/packages/cre8-mcp/dist/app.js
@@ -13,11 +13,23 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { handleGetPatterns, handleSearchComponents, handleListComponents, handleGetComponent, handleGenerateCode, handleGetA2uiCatalog, handleValidateA2uiSpec, } from './handlers.js';
 import { handleGetA2uiContext } from './a2ui-context.js';
+import { RateLimiter, isAlwaysOpenPath, isMultiTenant, isPrivilegedPath, loadTenantConfig, resolveTenant, } from './tenants.js';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import { Cre8GuideSchema, GetContentModelSchema, handleCre8Guide, handleGetContentModel } from './knowledge-tools.js';
 import { GetCompositionSchema, handleGetComposition } from './composition.js';
 import { mountSurfaceApi, mountSurfaceViewer } from './surface-routes.js';
 import { SERVER_VERSION, createMcpServer } from './mcp-server.js';
+/**
+ * Rate-limit bucket for an anonymous caller.
+ *
+ * Best-effort: behind a proxy every caller can share an address, so this
+ * throttles a runaway client rather than isolating users from each other.
+ */
+function clientKey(c) {
+    return (c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ||
+        c.req.header('x-real-ip') ||
+        'unknown');
+}
 export function createApp(options = {}) {
     const port = options.port ?? parseInt(process.env.PORT || '3001', 10);
     const token = options.token ?? process.env.CRE8_MCP_TOKEN;
@@ -35,14 +47,54 @@ export function createApp(options = {}) {
     // an Authorization header on a page load or an EventSource. Surface ids are 128
     // random bits, so the URL itself is the capability.
     mountSurfaceViewer(app);
-    // Bearer token gate — set CRE8_MCP_TOKEN to enable; skip for /health
+    /**
+     * Access control.
+     *
+     * Single-tenant (only `CRE8_MCP_TOKEN` set) behaves exactly as before: one
+     * token, gating everything but `/health`. Per-tenant mode is opt-in via
+     * `CRE8_MCP_TENANTS`, so upgrading never loosens an existing deployment.
+     *
+     * In per-tenant mode the split follows what is actually sensitive. The
+     * catalog is derived from a public npm package, so gating it protects
+     * nothing — anonymous callers get it, rate limited. Surface ids are
+     * unguessable capabilities that `GET /surfaces` enumerates, so those stay
+     * closed.
+     */
+    // `legacyToken` follows the *effective* token, not the environment, so a
+    // caller that injects one (tests, embedders) is honoured.
+    const tenantConfig = options.tenants ?? { ...loadTenantConfig(), legacyToken: token || undefined };
+    const limiter = options.rateLimiter ?? new RateLimiter();
+    const multiTenant = isMultiTenant(tenantConfig);
     app.use('*', async (c, next) => {
-        if (!token)
+        const path = new URL(c.req.url).pathname;
+        if (isAlwaysOpenPath(path))
             return next();
-        const auth = c.req.header('authorization') ?? '';
-        if (!auth.startsWith('Bearer ') || auth.slice(7) !== token) {
-            return c.json({ error: 'Unauthorized' }, 401);
+        const authorization = c.req.header('authorization');
+        const tenant = resolveTenant(tenantConfig, authorization);
+        if (!multiTenant) {
+            if (!token)
+                return next();
+            if (!tenant)
+                return c.json({ error: 'Unauthorized' }, 401);
+            return next();
         }
+        if (!tenant && isPrivilegedPath(path)) {
+            return c.json({ error: 'Unauthorized', detail: 'Surfaces require a tenant token.' }, 401);
+        }
+        if (!tenant && authorization) {
+            // A token was offered and not recognised. Falling through to anonymous
+            // would silently downgrade a caller who believes they are authenticated.
+            return c.json({ error: 'Unauthorized', detail: 'Unrecognised token.' }, 401);
+        }
+        const now = Date.now();
+        const key = tenant ? `t:${tenant.id}` : `anon:${clientKey(c)}`;
+        const limit = tenant ? tenant.limit : tenantConfig.anonymousLimit;
+        const retryAfter = limiter.check(key, limit, now);
+        if (retryAfter !== null) {
+            return c.json({ error: 'Too Many Requests', detail: `Limit is ${limit}/min.`, retryAfter }, 429, { 'Retry-After': String(retryAfter) });
+        }
+        if (limiter.size > 10_000)
+            limiter.sweep(now);
         return next();
     });
     // Info endpoint

--- a/packages/cre8-mcp/dist/tenants.d.ts
+++ b/packages/cre8-mcp/dist/tenants.d.ts
@@ -1,0 +1,71 @@
+/**
+ * Per-tenant access to the knowledge plane.
+ *
+ * The plane holds no model key and calls no model, and everything it serves is
+ * derived from the public `@tmorrow/cre8-wc` package — so its catalog is not a
+ * secret and gating it behind a shared password protects nothing. What auth is
+ * actually for here is rate limiting, attributing usage, and later, entitling a
+ * tenant to a private catalog.
+ *
+ * Two routes classes, because they have genuinely different threat models:
+ *
+ * - **Knowledge** (catalog, context, search, validate, generate) is public
+ *   information. Anonymous callers are allowed, with a low rate limit.
+ * - **Surfaces** are not. `GET /surfaces` hands out ids that the streaming UI
+ *   treats as unguessable capabilities, so an open surface API is not merely
+ *   readable, it is enumerable. These always require a tenant.
+ *
+ * Backwards compatible by construction: with only `CRE8_MCP_TOKEN` set the
+ * server behaves exactly as it did — one token, gating everything. Per-tenant
+ * mode is opt-in via `CRE8_MCP_TENANTS`, so no existing deployment loosens
+ * because it upgraded.
+ */
+export interface Tenant {
+    id: string;
+    /** Requests per minute. `null` means unlimited. */
+    limit: number | null;
+}
+export interface TenantConfig {
+    /** Legacy single token. When set alone, every route requires it. */
+    legacyToken?: string;
+    /** token -> tenant. Presence of any entry enables per-tenant mode. */
+    tenants: Map<string, Tenant>;
+    /** Requests per minute for callers with no token. */
+    anonymousLimit: number;
+}
+/**
+ * `CRE8_MCP_TENANTS` is JSON: `{"token-abc":{"id":"acme","limit":600}}`.
+ * A malformed value is a startup error rather than a silent fallback to open —
+ * failing closed is the only safe direction for an auth config.
+ */
+export declare function loadTenantConfig(env?: NodeJS.ProcessEnv): TenantConfig;
+/** True when per-tenant mode is configured. */
+export declare function isMultiTenant(config: TenantConfig): boolean;
+export declare function resolveTenant(config: TenantConfig, authorization: string | undefined): Tenant | null;
+/**
+ * Fixed-window counter, per process.
+ *
+ * Deliberately not a distributed limiter: this exists to stop a runaway client
+ * from monopolising one instance, not to enforce a billing quota. Anything
+ * stronger belongs in front of the process, and pretending otherwise would give
+ * false assurance.
+ */
+export declare class RateLimiter {
+    private readonly windowMs;
+    private readonly windows;
+    constructor(windowMs?: number);
+    /** Returns null when allowed, or the seconds to wait when over limit. */
+    check(key: string, limit: number | null, now: number): number | null;
+    /** Drops expired windows so a long-lived process does not grow unbounded. */
+    sweep(now: number): void;
+    get size(): number;
+}
+/**
+ * Routes that expose capabilities rather than public information.
+ *
+ * Surface ids are unguessable-by-design and `GET /surfaces` lists them, so this
+ * set stays closed to anonymous callers even in per-tenant mode.
+ */
+export declare function isPrivilegedPath(path: string): boolean;
+/** Reachable with no credentials at all, in any mode. */
+export declare function isAlwaysOpenPath(path: string): boolean;

--- a/packages/cre8-mcp/dist/tenants.js
+++ b/packages/cre8-mcp/dist/tenants.js
@@ -1,0 +1,128 @@
+/**
+ * Per-tenant access to the knowledge plane.
+ *
+ * The plane holds no model key and calls no model, and everything it serves is
+ * derived from the public `@tmorrow/cre8-wc` package — so its catalog is not a
+ * secret and gating it behind a shared password protects nothing. What auth is
+ * actually for here is rate limiting, attributing usage, and later, entitling a
+ * tenant to a private catalog.
+ *
+ * Two routes classes, because they have genuinely different threat models:
+ *
+ * - **Knowledge** (catalog, context, search, validate, generate) is public
+ *   information. Anonymous callers are allowed, with a low rate limit.
+ * - **Surfaces** are not. `GET /surfaces` hands out ids that the streaming UI
+ *   treats as unguessable capabilities, so an open surface API is not merely
+ *   readable, it is enumerable. These always require a tenant.
+ *
+ * Backwards compatible by construction: with only `CRE8_MCP_TOKEN` set the
+ * server behaves exactly as it did — one token, gating everything. Per-tenant
+ * mode is opt-in via `CRE8_MCP_TENANTS`, so no existing deployment loosens
+ * because it upgraded.
+ */
+const ANONYMOUS_DEFAULT = 60;
+/**
+ * `CRE8_MCP_TENANTS` is JSON: `{"token-abc":{"id":"acme","limit":600}}`.
+ * A malformed value is a startup error rather than a silent fallback to open —
+ * failing closed is the only safe direction for an auth config.
+ */
+export function loadTenantConfig(env = process.env) {
+    const tenants = new Map();
+    const raw = env.CRE8_MCP_TENANTS;
+    if (raw) {
+        let parsed;
+        try {
+            parsed = JSON.parse(raw);
+        }
+        catch {
+            throw new Error('CRE8_MCP_TENANTS is not valid JSON; refusing to start with an unreadable auth config');
+        }
+        for (const [token, value] of Object.entries(parsed)) {
+            if (!token)
+                continue;
+            tenants.set(token, {
+                id: value?.id ?? 'unnamed',
+                limit: value?.limit === null ? null : (value?.limit ?? 600),
+            });
+        }
+    }
+    const anonymousLimit = env.CRE8_MCP_ANON_LIMIT
+        ? Number(env.CRE8_MCP_ANON_LIMIT)
+        : ANONYMOUS_DEFAULT;
+    return {
+        legacyToken: env.CRE8_MCP_TOKEN || undefined,
+        tenants,
+        anonymousLimit: Number.isFinite(anonymousLimit) && anonymousLimit > 0 ? anonymousLimit : ANONYMOUS_DEFAULT,
+    };
+}
+/** True when per-tenant mode is configured. */
+export function isMultiTenant(config) {
+    return config.tenants.size > 0;
+}
+export function resolveTenant(config, authorization) {
+    if (!authorization?.startsWith('Bearer '))
+        return null;
+    const token = authorization.slice(7);
+    const tenant = config.tenants.get(token);
+    if (tenant)
+        return tenant;
+    // The legacy token behaves as an unlimited tenant so existing deployments
+    // keep working unchanged when they adopt per-tenant mode incrementally.
+    if (config.legacyToken && token === config.legacyToken) {
+        return { id: 'legacy', limit: null };
+    }
+    return null;
+}
+/**
+ * Fixed-window counter, per process.
+ *
+ * Deliberately not a distributed limiter: this exists to stop a runaway client
+ * from monopolising one instance, not to enforce a billing quota. Anything
+ * stronger belongs in front of the process, and pretending otherwise would give
+ * false assurance.
+ */
+export class RateLimiter {
+    windowMs;
+    windows = new Map();
+    constructor(windowMs = 60_000) {
+        this.windowMs = windowMs;
+    }
+    /** Returns null when allowed, or the seconds to wait when over limit. */
+    check(key, limit, now) {
+        if (limit === null)
+            return null;
+        const window = this.windows.get(key);
+        if (!window || now >= window.resetAt) {
+            this.windows.set(key, { count: 1, resetAt: now + this.windowMs });
+            return null;
+        }
+        if (window.count >= limit) {
+            return Math.max(1, Math.ceil((window.resetAt - now) / 1000));
+        }
+        window.count += 1;
+        return null;
+    }
+    /** Drops expired windows so a long-lived process does not grow unbounded. */
+    sweep(now) {
+        for (const [key, window] of this.windows) {
+            if (now >= window.resetAt)
+                this.windows.delete(key);
+        }
+    }
+    get size() {
+        return this.windows.size;
+    }
+}
+/**
+ * Routes that expose capabilities rather than public information.
+ *
+ * Surface ids are unguessable-by-design and `GET /surfaces` lists them, so this
+ * set stays closed to anonymous callers even in per-tenant mode.
+ */
+export function isPrivilegedPath(path) {
+    return path === '/surfaces' || path.startsWith('/surfaces/');
+}
+/** Reachable with no credentials at all, in any mode. */
+export function isAlwaysOpenPath(path) {
+    return path === '/health';
+}

--- a/packages/cre8-mcp/package.json
+++ b/packages/cre8-mcp/package.json
@@ -15,7 +15,7 @@
     "start": "node dist/index.js",
     "start:api": "node dist/server.js",
     "dev:api": "npx tsx watch src/server.ts",
-    "test": "npx tsx test/surface-api.test.mjs && npx tsx test/stdio-viewer.test.mjs && npx tsx test/a2ui-context.test.mjs"
+    "test": "npx tsx test/surface-api.test.mjs && npx tsx test/stdio-viewer.test.mjs && npx tsx test/a2ui-context.test.mjs && npx tsx test/tenants.test.mjs"
   },
   "keywords": [
     "mcp",

--- a/packages/cre8-mcp/src/app.ts
+++ b/packages/cre8-mcp/src/app.ts
@@ -23,6 +23,15 @@ import {
 } from './handlers.js';
 import type { GetPatternsInput, SearchComponentsInput, GenerateCodeInput } from './handlers.js';
 import { handleGetA2uiContext } from './a2ui-context.js';
+import {
+  RateLimiter,
+  isAlwaysOpenPath,
+  isMultiTenant,
+  isPrivilegedPath,
+  loadTenantConfig,
+  resolveTenant,
+  type TenantConfig,
+} from './tenants.js';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import { Cre8GuideSchema, GetContentModelSchema, handleCre8Guide, handleGetContentModel } from './knowledge-tools.js';
 import { GetCompositionSchema, handleGetComposition } from './composition.js';
@@ -34,6 +43,24 @@ export interface AppOptions {
   port?: number;
   /** Overrides $CRE8_MCP_TOKEN. Pass an empty string to disable the gate. */
   token?: string;
+  /** Overrides $CRE8_MCP_TENANTS. Injected by tests. */
+  tenants?: TenantConfig;
+  /** Injected by tests so limits can be exercised without waiting a minute. */
+  rateLimiter?: RateLimiter;
+}
+
+/**
+ * Rate-limit bucket for an anonymous caller.
+ *
+ * Best-effort: behind a proxy every caller can share an address, so this
+ * throttles a runaway client rather than isolating users from each other.
+ */
+function clientKey(c: { req: { header: (name: string) => string | undefined } }): string {
+  return (
+    c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ||
+    c.req.header('x-real-ip') ||
+    'unknown'
+  );
 }
 
 export function createApp(options: AppOptions = {}): Hono {
@@ -60,13 +87,60 @@ export function createApp(options: AppOptions = {}): Hono {
   // random bits, so the URL itself is the capability.
   mountSurfaceViewer(app);
 
-  // Bearer token gate — set CRE8_MCP_TOKEN to enable; skip for /health
+  /**
+   * Access control.
+   *
+   * Single-tenant (only `CRE8_MCP_TOKEN` set) behaves exactly as before: one
+   * token, gating everything but `/health`. Per-tenant mode is opt-in via
+   * `CRE8_MCP_TENANTS`, so upgrading never loosens an existing deployment.
+   *
+   * In per-tenant mode the split follows what is actually sensitive. The
+   * catalog is derived from a public npm package, so gating it protects
+   * nothing — anonymous callers get it, rate limited. Surface ids are
+   * unguessable capabilities that `GET /surfaces` enumerates, so those stay
+   * closed.
+   */
+  // `legacyToken` follows the *effective* token, not the environment, so a
+  // caller that injects one (tests, embedders) is honoured.
+  const tenantConfig = options.tenants ?? { ...loadTenantConfig(), legacyToken: token || undefined };
+  const limiter = options.rateLimiter ?? new RateLimiter();
+  const multiTenant = isMultiTenant(tenantConfig);
+
   app.use('*', async (c, next) => {
-    if (!token) return next();
-    const auth = c.req.header('authorization') ?? '';
-    if (!auth.startsWith('Bearer ') || auth.slice(7) !== token) {
-      return c.json({ error: 'Unauthorized' }, 401);
+    const path = new URL(c.req.url).pathname;
+    if (isAlwaysOpenPath(path)) return next();
+
+    const authorization = c.req.header('authorization');
+    const tenant = resolveTenant(tenantConfig, authorization);
+
+    if (!multiTenant) {
+      if (!token) return next();
+      if (!tenant) return c.json({ error: 'Unauthorized' }, 401);
+      return next();
     }
+
+    if (!tenant && isPrivilegedPath(path)) {
+      return c.json({ error: 'Unauthorized', detail: 'Surfaces require a tenant token.' }, 401);
+    }
+    if (!tenant && authorization) {
+      // A token was offered and not recognised. Falling through to anonymous
+      // would silently downgrade a caller who believes they are authenticated.
+      return c.json({ error: 'Unauthorized', detail: 'Unrecognised token.' }, 401);
+    }
+
+    const now = Date.now();
+    const key = tenant ? `t:${tenant.id}` : `anon:${clientKey(c)}`;
+    const limit = tenant ? tenant.limit : tenantConfig.anonymousLimit;
+    const retryAfter = limiter.check(key, limit, now);
+    if (retryAfter !== null) {
+      return c.json(
+        { error: 'Too Many Requests', detail: `Limit is ${limit}/min.`, retryAfter },
+        429,
+        { 'Retry-After': String(retryAfter) }
+      );
+    }
+    if (limiter.size > 10_000) limiter.sweep(now);
+
     return next();
   });
 

--- a/packages/cre8-mcp/src/tenants.ts
+++ b/packages/cre8-mcp/src/tenants.ts
@@ -1,0 +1,149 @@
+/**
+ * Per-tenant access to the knowledge plane.
+ *
+ * The plane holds no model key and calls no model, and everything it serves is
+ * derived from the public `@tmorrow/cre8-wc` package — so its catalog is not a
+ * secret and gating it behind a shared password protects nothing. What auth is
+ * actually for here is rate limiting, attributing usage, and later, entitling a
+ * tenant to a private catalog.
+ *
+ * Two routes classes, because they have genuinely different threat models:
+ *
+ * - **Knowledge** (catalog, context, search, validate, generate) is public
+ *   information. Anonymous callers are allowed, with a low rate limit.
+ * - **Surfaces** are not. `GET /surfaces` hands out ids that the streaming UI
+ *   treats as unguessable capabilities, so an open surface API is not merely
+ *   readable, it is enumerable. These always require a tenant.
+ *
+ * Backwards compatible by construction: with only `CRE8_MCP_TOKEN` set the
+ * server behaves exactly as it did — one token, gating everything. Per-tenant
+ * mode is opt-in via `CRE8_MCP_TENANTS`, so no existing deployment loosens
+ * because it upgraded.
+ */
+
+export interface Tenant {
+  id: string;
+  /** Requests per minute. `null` means unlimited. */
+  limit: number | null;
+}
+
+export interface TenantConfig {
+  /** Legacy single token. When set alone, every route requires it. */
+  legacyToken?: string;
+  /** token -> tenant. Presence of any entry enables per-tenant mode. */
+  tenants: Map<string, Tenant>;
+  /** Requests per minute for callers with no token. */
+  anonymousLimit: number;
+}
+
+const ANONYMOUS_DEFAULT = 60;
+
+/**
+ * `CRE8_MCP_TENANTS` is JSON: `{"token-abc":{"id":"acme","limit":600}}`.
+ * A malformed value is a startup error rather than a silent fallback to open —
+ * failing closed is the only safe direction for an auth config.
+ */
+export function loadTenantConfig(env: NodeJS.ProcessEnv = process.env): TenantConfig {
+  const tenants = new Map<string, Tenant>();
+  const raw = env.CRE8_MCP_TENANTS;
+
+  if (raw) {
+    let parsed: Record<string, { id?: string; limit?: number | null }>;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new Error('CRE8_MCP_TENANTS is not valid JSON; refusing to start with an unreadable auth config');
+    }
+    for (const [token, value] of Object.entries(parsed)) {
+      if (!token) continue;
+      tenants.set(token, {
+        id: value?.id ?? 'unnamed',
+        limit: value?.limit === null ? null : (value?.limit ?? 600),
+      });
+    }
+  }
+
+  const anonymousLimit = env.CRE8_MCP_ANON_LIMIT
+    ? Number(env.CRE8_MCP_ANON_LIMIT)
+    : ANONYMOUS_DEFAULT;
+
+  return {
+    legacyToken: env.CRE8_MCP_TOKEN || undefined,
+    tenants,
+    anonymousLimit: Number.isFinite(anonymousLimit) && anonymousLimit > 0 ? anonymousLimit : ANONYMOUS_DEFAULT,
+  };
+}
+
+/** True when per-tenant mode is configured. */
+export function isMultiTenant(config: TenantConfig): boolean {
+  return config.tenants.size > 0;
+}
+
+export function resolveTenant(config: TenantConfig, authorization: string | undefined): Tenant | null {
+  if (!authorization?.startsWith('Bearer ')) return null;
+  const token = authorization.slice(7);
+  const tenant = config.tenants.get(token);
+  if (tenant) return tenant;
+  // The legacy token behaves as an unlimited tenant so existing deployments
+  // keep working unchanged when they adopt per-tenant mode incrementally.
+  if (config.legacyToken && token === config.legacyToken) {
+    return { id: 'legacy', limit: null };
+  }
+  return null;
+}
+
+/**
+ * Fixed-window counter, per process.
+ *
+ * Deliberately not a distributed limiter: this exists to stop a runaway client
+ * from monopolising one instance, not to enforce a billing quota. Anything
+ * stronger belongs in front of the process, and pretending otherwise would give
+ * false assurance.
+ */
+export class RateLimiter {
+  private readonly windows = new Map<string, { count: number; resetAt: number }>();
+
+  constructor(private readonly windowMs = 60_000) {}
+
+  /** Returns null when allowed, or the seconds to wait when over limit. */
+  check(key: string, limit: number | null, now: number): number | null {
+    if (limit === null) return null;
+
+    const window = this.windows.get(key);
+    if (!window || now >= window.resetAt) {
+      this.windows.set(key, { count: 1, resetAt: now + this.windowMs });
+      return null;
+    }
+    if (window.count >= limit) {
+      return Math.max(1, Math.ceil((window.resetAt - now) / 1000));
+    }
+    window.count += 1;
+    return null;
+  }
+
+  /** Drops expired windows so a long-lived process does not grow unbounded. */
+  sweep(now: number): void {
+    for (const [key, window] of this.windows) {
+      if (now >= window.resetAt) this.windows.delete(key);
+    }
+  }
+
+  get size(): number {
+    return this.windows.size;
+  }
+}
+
+/**
+ * Routes that expose capabilities rather than public information.
+ *
+ * Surface ids are unguessable-by-design and `GET /surfaces` lists them, so this
+ * set stays closed to anonymous callers even in per-tenant mode.
+ */
+export function isPrivilegedPath(path: string): boolean {
+  return path === '/surfaces' || path.startsWith('/surfaces/');
+}
+
+/** Reachable with no credentials at all, in any mode. */
+export function isAlwaysOpenPath(path: string): boolean {
+  return path === '/health';
+}

--- a/packages/cre8-mcp/test/tenants.test.mjs
+++ b/packages/cre8-mcp/test/tenants.test.mjs
@@ -1,0 +1,177 @@
+/**
+ * Per-tenant access to the knowledge plane.
+ *
+ *   npx tsx test/tenants.test.mjs
+ *
+ * The two properties that matter: upgrading must not loosen an existing
+ * single-token deployment, and enabling per-tenant mode must not open the
+ * surface API, which hands out unguessable ids.
+ */
+
+const { createApp } = await import('../src/app.ts');
+const { RateLimiter, loadTenantConfig } = await import('../src/tenants.ts');
+
+let passed = 0;
+const failures = [];
+
+async function test(name, fn) {
+  try {
+    await fn();
+    passed++;
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    failures.push(name);
+    console.log(`FAIL  ${name}\n      ${err.message}`);
+  }
+}
+
+function assert(cond, message) {
+  if (!cond) throw new Error(message ?? 'assertion failed');
+}
+
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message ?? 'not equal'}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+const tenantConfig = (overrides = {}) => ({
+  legacyToken: undefined,
+  tenants: new Map([
+    ['tok-acme', { id: 'acme', limit: 5 }],
+    ['tok-unlimited', { id: 'unlimited', limit: null }],
+  ]),
+  anonymousLimit: 3,
+  ...overrides,
+});
+
+const multi = (extra = {}) =>
+  createApp({ port: 3999, token: '', tenants: tenantConfig(), rateLimiter: new RateLimiter(), ...extra });
+
+const bearer = (t) => ({ headers: { authorization: `Bearer ${t}` } });
+
+// ── Backwards compatibility ──────────────────────────────────────────
+
+await test('single-token mode is unchanged: the token gates the API', async () => {
+  const app = createApp({ port: 3999, token: 'secret' });
+  assertEqual((await app.request('/components')).status, 401, 'no token');
+  assertEqual((await app.request('/components', bearer('secret'))).status, 200, 'with token');
+  assertEqual((await app.request('/health')).status, 200, 'health stays open');
+});
+
+await test('no token configured leaves everything open, as before', async () => {
+  const app = createApp({ port: 3999, token: '' });
+  assertEqual((await app.request('/components')).status, 200);
+});
+
+// ── Per-tenant mode ──────────────────────────────────────────────────
+
+await test('knowledge is readable anonymously, because the catalog is public', async () => {
+  const app = multi();
+  assertEqual((await app.request('/components')).status, 200, '/components');
+  assertEqual((await app.request('/a2ui/context?categories=Actions')).status, 200, '/a2ui/context');
+});
+
+await test('surfaces stay closed to anonymous callers — ids are capabilities', async () => {
+  const app = multi();
+  const res = await app.request('/surfaces', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+  assertEqual(res.status, 401, 'anonymous POST /surfaces');
+  const body = await res.json();
+  assert(/tenant token/i.test(body.detail ?? ''), `expected an explanatory detail, got ${JSON.stringify(body)}`);
+});
+
+await test('a tenant token opens the surface API', async () => {
+  const app = multi();
+  const res = await app.request('/surfaces', {
+    method: 'POST',
+    headers: { authorization: 'Bearer tok-acme', 'content-type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+  assertEqual(res.status, 201, 'creating a surface answers 201');
+});
+
+await test('an unrecognised token is rejected, not silently downgraded to anonymous', async () => {
+  const app = multi();
+  const res = await app.request('/components', bearer('tok-nope'));
+  assertEqual(res.status, 401, 'a caller who thinks they are authenticated must not be treated as anonymous');
+});
+
+await test('the legacy token still works alongside per-tenant config', async () => {
+  const app = createApp({
+    port: 3999,
+    token: '',
+    tenants: tenantConfig({ legacyToken: 'old-secret' }),
+    rateLimiter: new RateLimiter(),
+  });
+  assertEqual((await app.request('/components', bearer('old-secret'))).status, 200);
+});
+
+// ── Rate limiting ────────────────────────────────────────────────────
+
+await test('anonymous callers are limited, and told when to retry', async () => {
+  const app = multi();
+  for (let i = 0; i < 3; i++) {
+    assertEqual((await app.request('/components')).status, 200, `request ${i + 1} within limit`);
+  }
+  const res = await app.request('/components');
+  assertEqual(res.status, 429, 'fourth request over a limit of 3');
+  assert(res.headers.get('Retry-After'), 'a 429 must say when to retry');
+});
+
+await test('a tenant gets its own, larger budget', async () => {
+  const app = multi();
+  // Exhaust the anonymous bucket first; the tenant must be unaffected by it.
+  for (let i = 0; i < 4; i++) await app.request('/components');
+  for (let i = 0; i < 5; i++) {
+    assertEqual((await app.request('/components', bearer('tok-acme'))).status, 200, `tenant request ${i + 1}`);
+  }
+  assertEqual((await app.request('/components', bearer('tok-acme'))).status, 429, 'sixth exceeds the tenant limit of 5');
+});
+
+await test('a null limit means unlimited', async () => {
+  const app = multi();
+  for (let i = 0; i < 20; i++) {
+    assertEqual((await app.request('/components', bearer('tok-unlimited'))).status, 200, `request ${i + 1}`);
+  }
+});
+
+await test('health is never rate limited, so probes cannot lock themselves out', async () => {
+  const app = multi();
+  for (let i = 0; i < 25; i++) {
+    assertEqual((await app.request('/health')).status, 200, `probe ${i + 1}`);
+  }
+});
+
+// ── Config loading ───────────────────────────────────────────────────
+
+await test('a malformed tenant config fails closed rather than opening the server', () => {
+  let threw = false;
+  try {
+    loadTenantConfig({ CRE8_MCP_TENANTS: '{not json' });
+  } catch {
+    threw = true;
+  }
+  assert(threw, 'an unreadable auth config must abort startup, not fall back to open');
+});
+
+await test('tenants parse from the environment with a default limit', () => {
+  const config = loadTenantConfig({ CRE8_MCP_TENANTS: '{"abc":{"id":"acme"}}' });
+  assertEqual(config.tenants.get('abc').id, 'acme');
+  assertEqual(config.tenants.get('abc').limit, 600);
+});
+
+await test('the rate limiter releases windows so a long-lived process does not grow', () => {
+  const limiter = new RateLimiter(1000);
+  limiter.check('a', 10, 0);
+  limiter.check('b', 10, 0);
+  assertEqual(limiter.size, 2);
+  limiter.sweep(2000);
+  assertEqual(limiter.size, 0);
+});
+
+console.log(`\n${passed} passed, ${failures.length} failed`);
+if (failures.length) process.exit(1);


### PR DESCRIPTION
## Description

The plane held **one shared token gating everything**. That doesn't scale to multiple consumers, and it protects the wrong thing: the plane holds no model key, calls no model, and serves data derived entirely from the **public** `@tmorrow/cre8-wc` package. Gating a public catalog behind a shared password secures nothing while making the plane awkward to adopt.

What auth is actually for here is rate limiting, attributing usage, and later entitling a tenant to a private catalog. So the split now follows what is genuinely sensitive:

| Class | Routes | Anonymous |
| --- | --- | --- |
| **Knowledge** | `/components`, `/patterns`, `/search`, `/a2ui/*`, `/generate`, `/react/*` | allowed, rate limited |
| **Surfaces** | `/surfaces`, `/surfaces/*` | **rejected** |
| **Health** | `/health` | always open, never limited |

Surfaces are the exception for a concrete reason: `GET /surfaces` enumerates ids that the streaming UI treats as unguessable capabilities. An open surface API isn't merely readable — it's *enumerable*.

## Backwards compatible by construction

With only `CRE8_MCP_TOKEN` set, the server behaves **exactly as before** — one token, gating everything but `/health`. The pre-existing suite proves it unchanged (51 + 4 + 12 passing, untouched).

Per-tenant mode is opt-in via `CRE8_MCP_TENANTS`, so no deployment loosens merely because it upgraded. The legacy token keeps working *alongside* tenants as an unlimited one, so migration can be incremental.

```bash
CRE8_MCP_TENANTS='{"tok-acme":{"id":"acme","limit":600},"tok-eng":{"id":"eng","limit":null}}'
CRE8_MCP_ANON_LIMIT=60   # optional, defaults to 60/min
```

## Three choices worth reviewing

**A malformed `CRE8_MCP_TENANTS` aborts startup** rather than falling back to open. Failing closed is the only safe direction for an auth config, and a silent fallback to "no auth" is exactly the bug you'd never notice.

**An unrecognised token is rejected, not downgraded to anonymous.** A caller who believes they're authenticated must never be silently treated as a stranger — that turns an auth misconfiguration into a confusing rate-limit error much later.

**The limiter is a per-process fixed window, and says so.** It stops a runaway client monopolising one instance. It is *not* a billing quota and won't behave like one across replicas; anything stronger belongs in front of the process. Documented in the source rather than left to be assumed.

## Scope

- [ ] __Bug fix__ - non-breaking change which fixes an issue
- [x] __New feature__ - non-breaking change which adds functionality
- [ ] __Breaking change__ - fix or feature that would cause existing functionality to change

## Quality Checks

- [ ] Resolves an issue - Github Issue and/or Jira story created; No duplicates
- [ ] Follows branch name convention
- [ ] Version updated per [Semantic Versioning](https://semver.org) standard, if needed
- [x] Documentation - CSS comments, JS comments, Doc blocks
- [x] Did you use CSS Logical Properties for your CSS? — n/a, no CSS
- [x] Create React wrapper — n/a, no new web components
- [x] Storybook WC, React — n/a, no component changes
- [x] Performed a self-guided visual regression test for each respective brand — n/a, server-side only
- [x] Did you add custom events in the WC? — n/a
- [ ] Updated CHANGELOG
- [x] I've performed a self-review of my code
- [x] My code passes linting and code quality checks
- [x] New and existing tests pass with my code changes
- [x] My code builds without generating new errors/warnings

## Verification

**14 new tests**, covering both directions:

- single-token mode unchanged; no-token mode still fully open
- knowledge readable anonymously; surfaces rejected with an explanatory `detail`
- tenant token opens surfaces
- unrecognised token → 401, not anonymous
- legacy token works alongside tenants
- anonymous limit enforced, `Retry-After` present on 429
- tenant budget is independent of the exhausted anonymous bucket
- `limit: null` means unlimited
- `/health` never limited, so probes can't lock themselves out
- malformed config fails closed
- limiter sweeps expired windows

| Suite | Result |
| --- | --- |
| `pnpm test:mcp` | 51 + 4 + 12 + **14 new** = 81 passed |
| `pnpm check:parity` | 13/13 |
| `pnpm test:a2ui` / `:agent` | PASS |
| studio tests + tsc | 27 passed, exit 0 |

While writing these, two of my own expectations were wrong and the suite caught both: the injected `token` option wasn't being threaded into the tenant config (caught by the *existing* backward-compat tests, which is what they're for), and `POST /surfaces` correctly answers **201**, not 200.

## Notes for the reviewer

- `dist/` is committed, matching the existing convention for this package.
- Nothing reads a tenant id yet — usage attribution has no consumer, so I left it out rather than threading an unused Hono context generic through the app.
- CHANGELOG not updated; happy to add an entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
