### PR TITLE
Add opt-in team key custody

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "kb:check-demo-attrs": "node docs/kb/tools/check-demo-attrs.mjs",
     "test:mcp": "pnpm --filter @tmorrow/cre8-mcp test",
     "test:agent": "pnpm --filter @tmorrow/cre8-agent-core test",
+    "test:custody": "pnpm --filter @tmorrow/cre8-key-custody test",
     "build:agent": "pnpm --filter @tmorrow/cre8-agent-core build",
     "test:a2ui": "pnpm --filter @tmorrow/cre8-wc test:a2ui",
     "audit:render": "pnpm --filter @tmorrow/cre8-wc audit:render",

--- a/packages/cre8-key-custody/dist/custody.d.ts
+++ b/packages/cre8-key-custody/dist/custody.d.ts
@@ -1,0 +1,90 @@
+import { type RootKeyProvider, type SealedSecret } from './envelope.js';
+/**
+ * Shared model keys for teams.
+ *
+ * The default posture stays client-only: an individual's key lives in their
+ * browser and never reaches a server. This exists for the case that posture
+ * cannot serve — a team that wants one credential, central revocation, and an
+ * audit trail rather than a key pasted into everyone's browser.
+ *
+ * Taking custody is a real obligation, so the design tries to hold as little as
+ * possible for as short as possible. Plaintext exists only inside `withKey`,
+ * only for the duration of one call, and is never returned to the caller,
+ * stored, or logged.
+ */
+export interface KeyRecord {
+    tenantId: string;
+    provider: string;
+    sealed: SealedSecret;
+    /** Non-reversible, for display and for detecting an unchanged rotation. */
+    fingerprint: string;
+    createdAt: string;
+    lastUsedAt?: string;
+}
+/**
+ * Persistence, deliberately abstract.
+ *
+ * No datastore is chosen here. Custody needs durable storage a team can revoke
+ * from, and picking one is an infrastructure decision rather than a library
+ * one — so this package ships the interface and an in-memory implementation for
+ * tests, and a deployment supplies the rest.
+ */
+export interface KeyRecordStore {
+    get(tenantId: string, provider: string): Promise<KeyRecord | null>;
+    put(record: KeyRecord): Promise<void>;
+    delete(tenantId: string, provider: string): Promise<void>;
+    listProviders(tenantId: string): Promise<string[]>;
+}
+export declare class InMemoryKeyRecordStore implements KeyRecordStore {
+    private readonly records;
+    private key;
+    get(tenantId: string, provider: string): Promise<KeyRecord | null>;
+    put(record: KeyRecord): Promise<void>;
+    delete(tenantId: string, provider: string): Promise<void>;
+    listProviders(tenantId: string): Promise<string[]>;
+}
+/** What happened, for an audit trail. Never carries key material. */
+export interface AuditEvent {
+    action: 'stored' | 'used' | 'revoked' | 'rejected';
+    tenantId: string;
+    provider: string;
+    fingerprint?: string;
+    reason?: string;
+    at: string;
+}
+export interface CustodyOptions {
+    root: RootKeyProvider;
+    store: KeyRecordStore;
+    /** Called for every custody operation. Must not throw. */
+    audit?: (event: AuditEvent) => void;
+}
+/**
+ * Short, non-reversible identifier for a key.
+ *
+ * Salted with the tenant so the same key held by two teams does not produce a
+ * matching fingerprint, which would leak that they share a credential.
+ */
+export declare function fingerprint(secret: string, tenantId: string): string;
+export declare class TeamKeyCustody {
+    private readonly options;
+    constructor(options: CustodyOptions);
+    private emit;
+    /** Seals a team key. The plaintext is not retained after this returns. */
+    store(tenantId: string, provider: string, secret: string): Promise<KeyRecord>;
+    /**
+     * Runs `use` with the decrypted key, then discards it.
+     *
+     * The key is passed *into* a callback rather than returned, so there is no
+     * handle a caller can hold, cache, or accidentally serialise. That is the
+     * whole point of the shape.
+     */
+    withKey<T>(tenantId: string, provider: string, use: (secret: string) => Promise<T>): Promise<T>;
+    revoke(tenantId: string, provider: string): Promise<void>;
+    /** Safe to render: metadata only, never the sealed material. */
+    describe(tenantId: string): Promise<Array<{
+        provider: string;
+        fingerprint: string;
+        createdAt: string;
+        lastUsedAt?: string;
+    }>>;
+}

--- a/packages/cre8-key-custody/dist/custody.js
+++ b/packages/cre8-key-custody/dist/custody.js
@@ -1,0 +1,102 @@
+import { createHash } from 'node:crypto';
+import { open, seal } from './envelope.js';
+export class InMemoryKeyRecordStore {
+    records = new Map();
+    key(t, p) {
+        return `${t}\u0000${p}`;
+    }
+    async get(tenantId, provider) {
+        return this.records.get(this.key(tenantId, provider)) ?? null;
+    }
+    async put(record) {
+        this.records.set(this.key(record.tenantId, record.provider), record);
+    }
+    async delete(tenantId, provider) {
+        this.records.delete(this.key(tenantId, provider));
+    }
+    async listProviders(tenantId) {
+        return [...this.records.values()].filter((r) => r.tenantId === tenantId).map((r) => r.provider);
+    }
+}
+/**
+ * Short, non-reversible identifier for a key.
+ *
+ * Salted with the tenant so the same key held by two teams does not produce a
+ * matching fingerprint, which would leak that they share a credential.
+ */
+export function fingerprint(secret, tenantId) {
+    return createHash('sha256').update(`${tenantId}\u0000${secret}`).digest('hex').slice(0, 12);
+}
+export class TeamKeyCustody {
+    options;
+    constructor(options) {
+        this.options = options;
+    }
+    emit(event) {
+        try {
+            this.options.audit?.({ ...event, at: new Date().toISOString() });
+        }
+        catch {
+            // An audit sink must never break the request it is describing.
+        }
+    }
+    /** Seals a team key. The plaintext is not retained after this returns. */
+    async store(tenantId, provider, secret) {
+        if (!secret.trim())
+            throw new Error('Refusing to store an empty key.');
+        const context = { tenantId, provider };
+        const record = {
+            tenantId,
+            provider,
+            sealed: await seal(secret, this.options.root, context),
+            fingerprint: fingerprint(secret, tenantId),
+            createdAt: new Date().toISOString(),
+        };
+        await this.options.store.put(record);
+        this.emit({ action: 'stored', tenantId, provider, fingerprint: record.fingerprint });
+        return record;
+    }
+    /**
+     * Runs `use` with the decrypted key, then discards it.
+     *
+     * The key is passed *into* a callback rather than returned, so there is no
+     * handle a caller can hold, cache, or accidentally serialise. That is the
+     * whole point of the shape.
+     */
+    async withKey(tenantId, provider, use) {
+        const record = await this.options.store.get(tenantId, provider);
+        if (!record) {
+            this.emit({ action: 'rejected', tenantId, provider, reason: 'no key on file' });
+            throw new Error(`No ${provider} key held for tenant "${tenantId}".`);
+        }
+        const secret = await open(record.sealed, this.options.root, { tenantId, provider });
+        this.emit({ action: 'used', tenantId, provider, fingerprint: record.fingerprint });
+        try {
+            return await use(secret);
+        }
+        finally {
+            await this.options.store.put({ ...record, lastUsedAt: new Date().toISOString() });
+        }
+    }
+    async revoke(tenantId, provider) {
+        await this.options.store.delete(tenantId, provider);
+        this.emit({ action: 'revoked', tenantId, provider });
+    }
+    /** Safe to render: metadata only, never the sealed material. */
+    async describe(tenantId) {
+        const providers = await this.options.store.listProviders(tenantId);
+        const out = [];
+        for (const provider of providers) {
+            const record = await this.options.store.get(tenantId, provider);
+            if (!record)
+                continue;
+            out.push({
+                provider: record.provider,
+                fingerprint: record.fingerprint,
+                createdAt: record.createdAt,
+                lastUsedAt: record.lastUsedAt,
+            });
+        }
+        return out;
+    }
+}

--- a/packages/cre8-key-custody/dist/envelope.d.ts
+++ b/packages/cre8-key-custody/dist/envelope.d.ts
@@ -1,0 +1,55 @@
+export interface SealedSecret {
+    /** Data key, encrypted by the root key. */
+    wrappedDataKey: string;
+    wrappedDataKeyIv: string;
+    wrappedDataKeyTag: string;
+    /** The secret, encrypted by the data key. */
+    ciphertext: string;
+    iv: string;
+    tag: string;
+    /** Identifies which root key sealed this, so rotation is detectable. */
+    rootKeyId: string;
+}
+export interface SealContext {
+    tenantId: string;
+    provider: string;
+}
+/**
+ * Wraps and unwraps data keys. A real deployment backs this with a KMS so the
+ * root key never enters application memory; `LocalRootKey` exists for tests and
+ * single-node deployments that accept that trade-off knowingly.
+ */
+export interface RootKeyProvider {
+    readonly id: string;
+    wrap(dataKey: Buffer, context: SealContext): Promise<{
+        wrapped: Buffer;
+        iv: Buffer;
+        tag: Buffer;
+    }>;
+    unwrap(wrapped: Buffer, iv: Buffer, tag: Buffer, context: SealContext): Promise<Buffer>;
+}
+export declare class RootKeyError extends Error {
+}
+/**
+ * Root key held in process memory.
+ *
+ * **Refuses to run on anything that is not 32 bytes of real entropy.** There is
+ * deliberately no development default: a custody system that silently falls back
+ * to a hardcoded key is worse than none, because it looks like protection while
+ * providing none, and nothing in a test suite would notice.
+ */
+export declare class LocalRootKey implements RootKeyProvider {
+    readonly id: string;
+    private readonly key;
+    constructor(material: string | Buffer, id?: string);
+    wrap(dataKey: Buffer, context: SealContext): Promise<{
+        wrapped: Buffer<ArrayBuffer>;
+        iv: NonSharedBuffer;
+        tag: NonSharedBuffer;
+    }>;
+    unwrap(wrapped: Buffer, iv: Buffer, tag: Buffer, context: SealContext): Promise<Buffer<ArrayBuffer>>;
+}
+export declare function seal(secret: string, root: RootKeyProvider, context: SealContext): Promise<SealedSecret>;
+export declare function open(sealed: SealedSecret, root: RootKeyProvider, context: SealContext): Promise<string>;
+/** Constant-time comparison, for callers verifying a fingerprint. */
+export declare function equals(a: string, b: string): boolean;

--- a/packages/cre8-key-custody/dist/envelope.js
+++ b/packages/cre8-key-custody/dist/envelope.js
@@ -1,0 +1,124 @@
+import { createCipheriv, createDecipheriv, randomBytes, timingSafeEqual } from 'node:crypto';
+/**
+ * Envelope encryption for a model key.
+ *
+ * A fresh 256-bit data key encrypts each secret; the data key itself is wrapped
+ * by a root key the application never stores. Two consequences matter: the
+ * database alone is useless without the root key, and rotating the root key
+ * rewraps records without re-encrypting secrets.
+ *
+ * AES-256-GCM throughout, so tampering is detected rather than decrypted into
+ * garbage. The tenant and provider are bound in as additional authenticated
+ * data, which makes a record from one tenant undecryptable in the context of
+ * another even if rows are swapped.
+ */
+const ALGORITHM = 'aes-256-gcm';
+const KEY_BYTES = 32;
+const IV_BYTES = 12;
+/** Binds a record to its owner, so rows cannot be moved between tenants. */
+function aad({ tenantId, provider }) {
+    return Buffer.from(`${tenantId}\u0000${provider}`, 'utf8');
+}
+function encrypt(plaintext, key, additional) {
+    const iv = randomBytes(IV_BYTES);
+    const cipher = createCipheriv(ALGORITHM, key, iv);
+    cipher.setAAD(additional);
+    const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    return { ciphertext, iv, tag: cipher.getAuthTag() };
+}
+function decrypt(ciphertext, key, iv, tag, additional) {
+    const decipher = createDecipheriv(ALGORITHM, key, iv);
+    decipher.setAAD(additional);
+    decipher.setAuthTag(tag);
+    return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+}
+export class RootKeyError extends Error {
+}
+/**
+ * Root key held in process memory.
+ *
+ * **Refuses to run on anything that is not 32 bytes of real entropy.** There is
+ * deliberately no development default: a custody system that silently falls back
+ * to a hardcoded key is worse than none, because it looks like protection while
+ * providing none, and nothing in a test suite would notice.
+ */
+export class LocalRootKey {
+    id;
+    key;
+    constructor(material, id = 'local-v1') {
+        const key = typeof material === 'string' ? Buffer.from(material, 'base64') : material;
+        if (key.length !== KEY_BYTES) {
+            throw new RootKeyError(`Root key must be exactly ${KEY_BYTES} bytes (base64 of 32 random bytes); got ${key.length}. ` +
+                `Generate one with: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"`);
+        }
+        if (looksLikePlaceholder(key)) {
+            throw new RootKeyError('Root key looks like a placeholder (low entropy or a repeated pattern). Refusing to start: ' +
+                'a predictable root key offers no protection while appearing to.');
+        }
+        this.key = key;
+        this.id = id;
+    }
+    async wrap(dataKey, context) {
+        const { ciphertext, iv, tag } = encrypt(dataKey, this.key, aad(context));
+        return { wrapped: ciphertext, iv, tag };
+    }
+    async unwrap(wrapped, iv, tag, context) {
+        return decrypt(wrapped, this.key, iv, tag, aad(context));
+    }
+}
+/** Catches all-zero, all-same-byte and short repeating material. */
+function looksLikePlaceholder(key) {
+    const first = key[0];
+    if (key.every((b) => b === first))
+        return true;
+    for (const period of [1, 2, 4, 8, 16]) {
+        let repeats = true;
+        for (let i = period; i < key.length; i++) {
+            if (key[i] !== key[i % period]) {
+                repeats = false;
+                break;
+            }
+        }
+        if (repeats)
+            return true;
+    }
+    const distinct = new Set(key).size;
+    return distinct < 8;
+}
+export async function seal(secret, root, context) {
+    if (!secret)
+        throw new Error('Refusing to seal an empty secret.');
+    const dataKey = randomBytes(KEY_BYTES);
+    const body = encrypt(Buffer.from(secret, 'utf8'), dataKey, aad(context));
+    const wrapped = await root.wrap(dataKey, context);
+    dataKey.fill(0);
+    return {
+        wrappedDataKey: wrapped.wrapped.toString('base64'),
+        wrappedDataKeyIv: wrapped.iv.toString('base64'),
+        wrappedDataKeyTag: wrapped.tag.toString('base64'),
+        ciphertext: body.ciphertext.toString('base64'),
+        iv: body.iv.toString('base64'),
+        tag: body.tag.toString('base64'),
+        rootKeyId: root.id,
+    };
+}
+export async function open(sealed, root, context) {
+    if (sealed.rootKeyId !== root.id) {
+        throw new RootKeyError(`Record was sealed with root key "${sealed.rootKeyId}" but "${root.id}" is configured. Rewrap before rotating.`);
+    }
+    const dataKey = await root.unwrap(Buffer.from(sealed.wrappedDataKey, 'base64'), Buffer.from(sealed.wrappedDataKeyIv, 'base64'), Buffer.from(sealed.wrappedDataKeyTag, 'base64'), context);
+    try {
+        return decrypt(Buffer.from(sealed.ciphertext, 'base64'), dataKey, Buffer.from(sealed.iv, 'base64'), Buffer.from(sealed.tag, 'base64'), aad(context)).toString('utf8');
+    }
+    finally {
+        dataKey.fill(0);
+    }
+}
+/** Constant-time comparison, for callers verifying a fingerprint. */
+export function equals(a, b) {
+    const left = Buffer.from(a, 'utf8');
+    const right = Buffer.from(b, 'utf8');
+    if (left.length !== right.length)
+        return false;
+    return timingSafeEqual(left, right);
+}

--- a/packages/cre8-key-custody/dist/index.d.ts
+++ b/packages/cre8-key-custody/dist/index.d.ts
@@ -1,0 +1,22 @@
+/**
+ * Team key custody for the cre8 harness.
+ *
+ * The default posture is client-only: an individual's model key lives in their
+ * browser and no server ever sees it. This package exists for the case that
+ * cannot serve — a team wanting one shared credential, central revocation, and
+ * an audit trail instead of a key pasted into everyone's browser.
+ *
+ * Three deliberate constraints:
+ *
+ *  1. **This is not the knowledge plane.** `cre8-mcp` holds no model key and
+ *     calls no model, and tests assert it. Custody lives here, in a package a
+ *     shell opts into, so adopting it cannot compromise that invariant.
+ *  2. **No weak defaults.** There is no development root key. Misconfiguration
+ *     fails startup rather than silently encrypting with something predictable,
+ *     which would look like protection while providing none.
+ *  3. **No storage decision.** `KeyRecordStore` is an interface with an
+ *     in-memory implementation for tests. Durable storage is an infrastructure
+ *     choice a deployment makes, not one a library should make for it.
+ */
+export { LocalRootKey, RootKeyError, equals, open, seal, type RootKeyProvider, type SealContext, type SealedSecret, } from './envelope.js';
+export { InMemoryKeyRecordStore, TeamKeyCustody, fingerprint, type AuditEvent, type CustodyOptions, type KeyRecord, type KeyRecordStore, } from './custody.js';

--- a/packages/cre8-key-custody/dist/index.js
+++ b/packages/cre8-key-custody/dist/index.js
@@ -1,0 +1,22 @@
+/**
+ * Team key custody for the cre8 harness.
+ *
+ * The default posture is client-only: an individual's model key lives in their
+ * browser and no server ever sees it. This package exists for the case that
+ * cannot serve — a team wanting one shared credential, central revocation, and
+ * an audit trail instead of a key pasted into everyone's browser.
+ *
+ * Three deliberate constraints:
+ *
+ *  1. **This is not the knowledge plane.** `cre8-mcp` holds no model key and
+ *     calls no model, and tests assert it. Custody lives here, in a package a
+ *     shell opts into, so adopting it cannot compromise that invariant.
+ *  2. **No weak defaults.** There is no development root key. Misconfiguration
+ *     fails startup rather than silently encrypting with something predictable,
+ *     which would look like protection while providing none.
+ *  3. **No storage decision.** `KeyRecordStore` is an interface with an
+ *     in-memory implementation for tests. Durable storage is an infrastructure
+ *     choice a deployment makes, not one a library should make for it.
+ */
+export { LocalRootKey, RootKeyError, equals, open, seal, } from './envelope.js';
+export { InMemoryKeyRecordStore, TeamKeyCustody, fingerprint, } from './custody.js';

--- a/packages/cre8-key-custody/package.json
+++ b/packages/cre8-key-custody/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@tmorrow/cre8-key-custody",
+  "version": "0.1.0",
+  "description": "Envelope-encrypted custody for shared team model keys. Opt-in; the default posture is client-only.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "npx tsx test/custody.test.mjs"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0"
+  }
+}

--- a/packages/cre8-key-custody/src/custody.ts
+++ b/packages/cre8-key-custody/src/custody.ts
@@ -1,0 +1,169 @@
+import { createHash } from 'node:crypto';
+import { open, seal, type RootKeyProvider, type SealedSecret } from './envelope.js';
+
+/**
+ * Shared model keys for teams.
+ *
+ * The default posture stays client-only: an individual's key lives in their
+ * browser and never reaches a server. This exists for the case that posture
+ * cannot serve — a team that wants one credential, central revocation, and an
+ * audit trail rather than a key pasted into everyone's browser.
+ *
+ * Taking custody is a real obligation, so the design tries to hold as little as
+ * possible for as short as possible. Plaintext exists only inside `withKey`,
+ * only for the duration of one call, and is never returned to the caller,
+ * stored, or logged.
+ */
+
+export interface KeyRecord {
+  tenantId: string;
+  provider: string;
+  sealed: SealedSecret;
+  /** Non-reversible, for display and for detecting an unchanged rotation. */
+  fingerprint: string;
+  createdAt: string;
+  lastUsedAt?: string;
+}
+
+/**
+ * Persistence, deliberately abstract.
+ *
+ * No datastore is chosen here. Custody needs durable storage a team can revoke
+ * from, and picking one is an infrastructure decision rather than a library
+ * one — so this package ships the interface and an in-memory implementation for
+ * tests, and a deployment supplies the rest.
+ */
+export interface KeyRecordStore {
+  get(tenantId: string, provider: string): Promise<KeyRecord | null>;
+  put(record: KeyRecord): Promise<void>;
+  delete(tenantId: string, provider: string): Promise<void>;
+  listProviders(tenantId: string): Promise<string[]>;
+}
+
+export class InMemoryKeyRecordStore implements KeyRecordStore {
+  private readonly records = new Map<string, KeyRecord>();
+  private key(t: string, p: string) {
+    return `${t}\u0000${p}`;
+  }
+
+  async get(tenantId: string, provider: string) {
+    return this.records.get(this.key(tenantId, provider)) ?? null;
+  }
+  async put(record: KeyRecord) {
+    this.records.set(this.key(record.tenantId, record.provider), record);
+  }
+  async delete(tenantId: string, provider: string) {
+    this.records.delete(this.key(tenantId, provider));
+  }
+  async listProviders(tenantId: string) {
+    return [...this.records.values()].filter((r) => r.tenantId === tenantId).map((r) => r.provider);
+  }
+}
+
+/** What happened, for an audit trail. Never carries key material. */
+export interface AuditEvent {
+  action: 'stored' | 'used' | 'revoked' | 'rejected';
+  tenantId: string;
+  provider: string;
+  fingerprint?: string;
+  reason?: string;
+  at: string;
+}
+
+export interface CustodyOptions {
+  root: RootKeyProvider;
+  store: KeyRecordStore;
+  /** Called for every custody operation. Must not throw. */
+  audit?: (event: AuditEvent) => void;
+}
+
+/**
+ * Short, non-reversible identifier for a key.
+ *
+ * Salted with the tenant so the same key held by two teams does not produce a
+ * matching fingerprint, which would leak that they share a credential.
+ */
+export function fingerprint(secret: string, tenantId: string): string {
+  return createHash('sha256').update(`${tenantId}\u0000${secret}`).digest('hex').slice(0, 12);
+}
+
+export class TeamKeyCustody {
+  constructor(private readonly options: CustodyOptions) {}
+
+  private emit(event: Omit<AuditEvent, 'at'>) {
+    try {
+      this.options.audit?.({ ...event, at: new Date().toISOString() });
+    } catch {
+      // An audit sink must never break the request it is describing.
+    }
+  }
+
+  /** Seals a team key. The plaintext is not retained after this returns. */
+  async store(tenantId: string, provider: string, secret: string): Promise<KeyRecord> {
+    if (!secret.trim()) throw new Error('Refusing to store an empty key.');
+
+    const context = { tenantId, provider };
+    const record: KeyRecord = {
+      tenantId,
+      provider,
+      sealed: await seal(secret, this.options.root, context),
+      fingerprint: fingerprint(secret, tenantId),
+      createdAt: new Date().toISOString(),
+    };
+    await this.options.store.put(record);
+    this.emit({ action: 'stored', tenantId, provider, fingerprint: record.fingerprint });
+    return record;
+  }
+
+  /**
+   * Runs `use` with the decrypted key, then discards it.
+   *
+   * The key is passed *into* a callback rather than returned, so there is no
+   * handle a caller can hold, cache, or accidentally serialise. That is the
+   * whole point of the shape.
+   */
+  async withKey<T>(
+    tenantId: string,
+    provider: string,
+    use: (secret: string) => Promise<T>
+  ): Promise<T> {
+    const record = await this.options.store.get(tenantId, provider);
+    if (!record) {
+      this.emit({ action: 'rejected', tenantId, provider, reason: 'no key on file' });
+      throw new Error(`No ${provider} key held for tenant "${tenantId}".`);
+    }
+
+    const secret = await open(record.sealed, this.options.root, { tenantId, provider });
+    this.emit({ action: 'used', tenantId, provider, fingerprint: record.fingerprint });
+
+    try {
+      return await use(secret);
+    } finally {
+      await this.options.store.put({ ...record, lastUsedAt: new Date().toISOString() });
+    }
+  }
+
+  async revoke(tenantId: string, provider: string): Promise<void> {
+    await this.options.store.delete(tenantId, provider);
+    this.emit({ action: 'revoked', tenantId, provider });
+  }
+
+  /** Safe to render: metadata only, never the sealed material. */
+  async describe(tenantId: string): Promise<
+    Array<{ provider: string; fingerprint: string; createdAt: string; lastUsedAt?: string }>
+  > {
+    const providers = await this.options.store.listProviders(tenantId);
+    const out = [];
+    for (const provider of providers) {
+      const record = await this.options.store.get(tenantId, provider);
+      if (!record) continue;
+      out.push({
+        provider: record.provider,
+        fingerprint: record.fingerprint,
+        createdAt: record.createdAt,
+        lastUsedAt: record.lastUsedAt,
+      });
+    }
+    return out;
+  }
+}

--- a/packages/cre8-key-custody/src/envelope.ts
+++ b/packages/cre8-key-custody/src/envelope.ts
@@ -1,0 +1,189 @@
+import { createCipheriv, createDecipheriv, randomBytes, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Envelope encryption for a model key.
+ *
+ * A fresh 256-bit data key encrypts each secret; the data key itself is wrapped
+ * by a root key the application never stores. Two consequences matter: the
+ * database alone is useless without the root key, and rotating the root key
+ * rewraps records without re-encrypting secrets.
+ *
+ * AES-256-GCM throughout, so tampering is detected rather than decrypted into
+ * garbage. The tenant and provider are bound in as additional authenticated
+ * data, which makes a record from one tenant undecryptable in the context of
+ * another even if rows are swapped.
+ */
+
+const ALGORITHM = 'aes-256-gcm';
+const KEY_BYTES = 32;
+const IV_BYTES = 12;
+
+export interface SealedSecret {
+  /** Data key, encrypted by the root key. */
+  wrappedDataKey: string;
+  wrappedDataKeyIv: string;
+  wrappedDataKeyTag: string;
+  /** The secret, encrypted by the data key. */
+  ciphertext: string;
+  iv: string;
+  tag: string;
+  /** Identifies which root key sealed this, so rotation is detectable. */
+  rootKeyId: string;
+}
+
+export interface SealContext {
+  tenantId: string;
+  provider: string;
+}
+
+/** Binds a record to its owner, so rows cannot be moved between tenants. */
+function aad({ tenantId, provider }: SealContext): Buffer {
+  return Buffer.from(`${tenantId}\u0000${provider}`, 'utf8');
+}
+
+function encrypt(plaintext: Buffer, key: Buffer, additional: Buffer) {
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  cipher.setAAD(additional);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  return { ciphertext, iv, tag: cipher.getAuthTag() };
+}
+
+function decrypt(ciphertext: Buffer, key: Buffer, iv: Buffer, tag: Buffer, additional: Buffer) {
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAAD(additional);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+}
+
+/**
+ * Wraps and unwraps data keys. A real deployment backs this with a KMS so the
+ * root key never enters application memory; `LocalRootKey` exists for tests and
+ * single-node deployments that accept that trade-off knowingly.
+ */
+export interface RootKeyProvider {
+  readonly id: string;
+  wrap(dataKey: Buffer, context: SealContext): Promise<{ wrapped: Buffer; iv: Buffer; tag: Buffer }>;
+  unwrap(wrapped: Buffer, iv: Buffer, tag: Buffer, context: SealContext): Promise<Buffer>;
+}
+
+export class RootKeyError extends Error {}
+
+/**
+ * Root key held in process memory.
+ *
+ * **Refuses to run on anything that is not 32 bytes of real entropy.** There is
+ * deliberately no development default: a custody system that silently falls back
+ * to a hardcoded key is worse than none, because it looks like protection while
+ * providing none, and nothing in a test suite would notice.
+ */
+export class LocalRootKey implements RootKeyProvider {
+  readonly id: string;
+  private readonly key: Buffer;
+
+  constructor(material: string | Buffer, id = 'local-v1') {
+    const key = typeof material === 'string' ? Buffer.from(material, 'base64') : material;
+
+    if (key.length !== KEY_BYTES) {
+      throw new RootKeyError(
+        `Root key must be exactly ${KEY_BYTES} bytes (base64 of 32 random bytes); got ${key.length}. ` +
+          `Generate one with: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"`
+      );
+    }
+    if (looksLikePlaceholder(key)) {
+      throw new RootKeyError(
+        'Root key looks like a placeholder (low entropy or a repeated pattern). Refusing to start: ' +
+          'a predictable root key offers no protection while appearing to.'
+      );
+    }
+
+    this.key = key;
+    this.id = id;
+  }
+
+  async wrap(dataKey: Buffer, context: SealContext) {
+    const { ciphertext, iv, tag } = encrypt(dataKey, this.key, aad(context));
+    return { wrapped: ciphertext, iv, tag };
+  }
+
+  async unwrap(wrapped: Buffer, iv: Buffer, tag: Buffer, context: SealContext) {
+    return decrypt(wrapped, this.key, iv, tag, aad(context));
+  }
+}
+
+/** Catches all-zero, all-same-byte and short repeating material. */
+function looksLikePlaceholder(key: Buffer): boolean {
+  const first = key[0];
+  if (key.every((b) => b === first)) return true;
+  for (const period of [1, 2, 4, 8, 16]) {
+    let repeats = true;
+    for (let i = period; i < key.length; i++) {
+      if (key[i] !== key[i % period]) {
+        repeats = false;
+        break;
+      }
+    }
+    if (repeats) return true;
+  }
+  const distinct = new Set(key).size;
+  return distinct < 8;
+}
+
+export async function seal(
+  secret: string,
+  root: RootKeyProvider,
+  context: SealContext
+): Promise<SealedSecret> {
+  if (!secret) throw new Error('Refusing to seal an empty secret.');
+  const dataKey = randomBytes(KEY_BYTES);
+  const body = encrypt(Buffer.from(secret, 'utf8'), dataKey, aad(context));
+  const wrapped = await root.wrap(dataKey, context);
+  dataKey.fill(0);
+
+  return {
+    wrappedDataKey: wrapped.wrapped.toString('base64'),
+    wrappedDataKeyIv: wrapped.iv.toString('base64'),
+    wrappedDataKeyTag: wrapped.tag.toString('base64'),
+    ciphertext: body.ciphertext.toString('base64'),
+    iv: body.iv.toString('base64'),
+    tag: body.tag.toString('base64'),
+    rootKeyId: root.id,
+  };
+}
+
+export async function open(
+  sealed: SealedSecret,
+  root: RootKeyProvider,
+  context: SealContext
+): Promise<string> {
+  if (sealed.rootKeyId !== root.id) {
+    throw new RootKeyError(
+      `Record was sealed with root key "${sealed.rootKeyId}" but "${root.id}" is configured. Rewrap before rotating.`
+    );
+  }
+  const dataKey = await root.unwrap(
+    Buffer.from(sealed.wrappedDataKey, 'base64'),
+    Buffer.from(sealed.wrappedDataKeyIv, 'base64'),
+    Buffer.from(sealed.wrappedDataKeyTag, 'base64'),
+    context
+  );
+  try {
+    return decrypt(
+      Buffer.from(sealed.ciphertext, 'base64'),
+      dataKey,
+      Buffer.from(sealed.iv, 'base64'),
+      Buffer.from(sealed.tag, 'base64'),
+      aad(context)
+    ).toString('utf8');
+  } finally {
+    dataKey.fill(0);
+  }
+}
+
+/** Constant-time comparison, for callers verifying a fingerprint. */
+export function equals(a: string, b: string): boolean {
+  const left = Buffer.from(a, 'utf8');
+  const right = Buffer.from(b, 'utf8');
+  if (left.length !== right.length) return false;
+  return timingSafeEqual(left, right);
+}

--- a/packages/cre8-key-custody/src/index.ts
+++ b/packages/cre8-key-custody/src/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Team key custody for the cre8 harness.
+ *
+ * The default posture is client-only: an individual's model key lives in their
+ * browser and no server ever sees it. This package exists for the case that
+ * cannot serve — a team wanting one shared credential, central revocation, and
+ * an audit trail instead of a key pasted into everyone's browser.
+ *
+ * Three deliberate constraints:
+ *
+ *  1. **This is not the knowledge plane.** `cre8-mcp` holds no model key and
+ *     calls no model, and tests assert it. Custody lives here, in a package a
+ *     shell opts into, so adopting it cannot compromise that invariant.
+ *  2. **No weak defaults.** There is no development root key. Misconfiguration
+ *     fails startup rather than silently encrypting with something predictable,
+ *     which would look like protection while providing none.
+ *  3. **No storage decision.** `KeyRecordStore` is an interface with an
+ *     in-memory implementation for tests. Durable storage is an infrastructure
+ *     choice a deployment makes, not one a library should make for it.
+ */
+
+export {
+  LocalRootKey,
+  RootKeyError,
+  equals,
+  open,
+  seal,
+  type RootKeyProvider,
+  type SealContext,
+  type SealedSecret,
+} from './envelope.js';
+
+export {
+  InMemoryKeyRecordStore,
+  TeamKeyCustody,
+  fingerprint,
+  type AuditEvent,
+  type CustodyOptions,
+  type KeyRecord,
+  type KeyRecordStore,
+} from './custody.js';

--- a/packages/cre8-key-custody/test/custody.test.mjs
+++ b/packages/cre8-key-custody/test/custody.test.mjs
@@ -1,0 +1,230 @@
+/**
+ * Team key custody.
+ *
+ *   npx tsx test/custody.test.mjs
+ *
+ * Custody is the part of the harness with a real obligation attached, so these
+ * lean on the properties that matter if something goes wrong: a stolen database
+ * is useless, records cannot be moved between tenants, tampering is detected,
+ * and plaintext never escapes the callback it is handed to.
+ */
+
+import { randomBytes } from 'node:crypto';
+
+const { LocalRootKey, RootKeyError, seal, open } = await import('../src/envelope.ts');
+const { TeamKeyCustody, InMemoryKeyRecordStore, fingerprint } = await import('../src/custody.ts');
+
+let passed = 0;
+const failures = [];
+
+async function test(name, fn) {
+  try {
+    await fn();
+    passed++;
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    failures.push(name);
+    console.log(`FAIL  ${name}\n      ${err.message}`);
+  }
+}
+
+function assert(cond, message) {
+  if (!cond) throw new Error(message ?? 'assertion failed');
+}
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message ?? 'not equal'}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+async function assertThrows(fn, message) {
+  try {
+    await fn();
+  } catch {
+    return;
+  }
+  throw new Error(message ?? 'expected a throw');
+}
+
+const rootMaterial = randomBytes(32);
+const root = () => new LocalRootKey(rootMaterial);
+const SECRET = 'AIza-team-key-not-real-000000000000';
+
+const custody = (audit) =>
+  new TeamKeyCustody({ root: root(), store: new InMemoryKeyRecordStore(), audit });
+
+// ── Refusing weak configuration ──────────────────────────────────────
+
+await test('a short root key is refused, with instructions', async () => {
+  try {
+    new LocalRootKey(Buffer.alloc(16, 7));
+    throw new Error('expected a throw');
+  } catch (err) {
+    assert(err instanceof RootKeyError, `wrong error type: ${err.message}`);
+    assert(/32 bytes/.test(err.message), 'the message should say what is required');
+    assert(/randomBytes/.test(err.message), 'the message should say how to generate one');
+  }
+});
+
+await test('an all-zero root key is refused as a placeholder', async () => {
+  await assertThrows(async () => new LocalRootKey(Buffer.alloc(32, 0)), 'all-zero key accepted');
+});
+
+await test('a repeating-pattern root key is refused', async () => {
+  const repeating = Buffer.from(Array.from({ length: 32 }, (_, i) => i % 4));
+  await assertThrows(async () => new LocalRootKey(repeating), 'repeating key accepted');
+});
+
+await test('real entropy is accepted', async () => {
+  new LocalRootKey(randomBytes(32));
+});
+
+// ── The properties that matter if a database leaks ───────────────────
+
+await test('the sealed record contains no trace of the plaintext', async () => {
+  const sealed = await seal(SECRET, root(), { tenantId: 'acme', provider: 'gemini' });
+  const serialised = JSON.stringify(sealed);
+  assert(!serialised.includes(SECRET), 'plaintext present in the sealed record');
+  assert(!serialised.includes(SECRET.slice(0, 12)), 'a prefix of the plaintext is present');
+});
+
+await test('a record is useless without the root key', async () => {
+  const sealed = await seal(SECRET, root(), { tenantId: 'acme', provider: 'gemini' });
+  const attacker = new LocalRootKey(randomBytes(32), 'local-v1');
+  await assertThrows(
+    () => open(sealed, attacker, { tenantId: 'acme', provider: 'gemini' }),
+    'a different root key decrypted the record'
+  );
+});
+
+await test('a record cannot be moved to another tenant', async () => {
+  const sealed = await seal(SECRET, root(), { tenantId: 'acme', provider: 'gemini' });
+  await assertThrows(
+    () => open(sealed, root(), { tenantId: 'other-co', provider: 'gemini' }),
+    'a record decrypted under the wrong tenant'
+  );
+});
+
+await test('a record cannot be reused for another provider', async () => {
+  const sealed = await seal(SECRET, root(), { tenantId: 'acme', provider: 'gemini' });
+  await assertThrows(
+    () => open(sealed, root(), { tenantId: 'acme', provider: 'anthropic' }),
+    'a record decrypted under the wrong provider'
+  );
+});
+
+await test('tampering is detected rather than decrypted into garbage', async () => {
+  const sealed = await seal(SECRET, root(), { tenantId: 'acme', provider: 'gemini' });
+  const bytes = Buffer.from(sealed.ciphertext, 'base64');
+  bytes[0] ^= 0xff;
+  const tampered = { ...sealed, ciphertext: bytes.toString('base64') };
+  await assertThrows(
+    () => open(tampered, root(), { tenantId: 'acme', provider: 'gemini' }),
+    'tampered ciphertext was accepted'
+  );
+});
+
+await test('rotating the root key is detected instead of failing obscurely', async () => {
+  const sealed = await seal(SECRET, root(), { tenantId: 'acme', provider: 'gemini' });
+  const rotated = new LocalRootKey(randomBytes(32), 'local-v2');
+  try {
+    await open(sealed, rotated, { tenantId: 'acme', provider: 'gemini' });
+    throw new Error('expected a throw');
+  } catch (err) {
+    assert(/Rewrap/.test(err.message), `expected rotation guidance, got: ${err.message}`);
+  }
+});
+
+await test('a round trip returns exactly the original secret', async () => {
+  const context = { tenantId: 'acme', provider: 'gemini' };
+  assertEqual(await open(await seal(SECRET, root(), context), root(), context), SECRET);
+});
+
+await test('each seal uses fresh material, so identical secrets differ on disk', async () => {
+  const context = { tenantId: 'acme', provider: 'gemini' };
+  const a = await seal(SECRET, root(), context);
+  const b = await seal(SECRET, root(), context);
+  assert(a.ciphertext !== b.ciphertext, 'ciphertext repeated across seals');
+  assert(a.wrappedDataKey !== b.wrappedDataKey, 'data key repeated across seals');
+});
+
+// ── The custody service ──────────────────────────────────────────────
+
+await test('the key is handed to a callback and never returned', async () => {
+  const service = custody();
+  await service.store('acme', 'gemini', SECRET);
+
+  let seen = null;
+  const result = await service.withKey('acme', 'gemini', async (secret) => {
+    seen = secret;
+    return 'called';
+  });
+
+  assertEqual(seen, SECRET, 'the callback must receive the real key');
+  assertEqual(result, 'called');
+  // There is deliberately no API that returns the plaintext.
+  assert(typeof service.get !== 'function', 'a plaintext getter must not exist');
+  assert(typeof service.reveal !== 'function', 'a plaintext getter must not exist');
+});
+
+await test('describe() exposes metadata but never key material', async () => {
+  const service = custody();
+  await service.store('acme', 'gemini', SECRET);
+  const described = JSON.stringify(await service.describe('acme'));
+  assert(!described.includes(SECRET), 'describe leaked the key');
+  assert(described.includes('fingerprint'), 'describe should carry a fingerprint');
+});
+
+await test('a fingerprint is not reversible and is salted per tenant', async () => {
+  const a = fingerprint(SECRET, 'acme');
+  const b = fingerprint(SECRET, 'other-co');
+  assert(!a.includes(SECRET.slice(0, 8)), 'fingerprint contains the key');
+  assert(a !== b, 'the same key must not fingerprint alike across tenants');
+});
+
+await test('revocation makes the key unusable immediately', async () => {
+  const service = custody();
+  await service.store('acme', 'gemini', SECRET);
+  await service.revoke('acme', 'gemini');
+  await assertThrows(
+    () => service.withKey('acme', 'gemini', async () => 'should not run'),
+    'a revoked key was still usable'
+  );
+});
+
+await test('one tenant cannot use another tenant key', async () => {
+  const service = custody();
+  await service.store('acme', 'gemini', SECRET);
+  await assertThrows(
+    () => service.withKey('other-co', 'gemini', async () => 'should not run'),
+    'cross-tenant access allowed'
+  );
+});
+
+await test('the audit trail records use without recording the key', async () => {
+  const events = [];
+  const service = custody((e) => events.push(e));
+  await service.store('acme', 'gemini', SECRET);
+  await service.withKey('acme', 'gemini', async () => 'ok');
+  await service.revoke('acme', 'gemini');
+
+  assertEqual(events.map((e) => e.action).join(','), 'stored,used,revoked');
+  const serialised = JSON.stringify(events);
+  assert(!serialised.includes(SECRET), 'the audit trail leaked the key');
+  assert(events.every((e) => e.at), 'every event needs a timestamp');
+});
+
+await test('a failing audit sink cannot break the operation it describes', async () => {
+  const service = custody(() => {
+    throw new Error('sink is down');
+  });
+  await service.store('acme', 'gemini', SECRET);
+  assertEqual(await service.withKey('acme', 'gemini', async () => 'ok'), 'ok');
+});
+
+await test('an empty key is refused rather than stored', async () => {
+  const service = custody();
+  await assertThrows(() => service.store('acme', 'gemini', '   '), 'an empty key was stored');
+});
+
+console.log(`\n${passed} passed, ${failures.length} failed`);
+if (failures.length) process.exit(1);

--- a/packages/cre8-key-custody/tsconfig.json
+++ b/packages/cre8-key-custody/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,12 @@ importers:
         specifier: ^5.6.0
         version: 5.9.3
 
+  packages/cre8-key-custody:
+    devDependencies:
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+
   packages/cre8-mcp:
     dependencies:
       '@hono/node-server':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,4 +2,5 @@ packages:
   - packages/cre8-wc
   - packages/cre8-mcp
   - packages/cre8-agent-core
+  - packages/cre8-key-custody
   - packages/cre8-studio


### PR DESCRIPTION
## Description

Step 6 of the harness plan, and the one with a real obligation attached.

**The default posture is unchanged: client-only.** An individual's model key lives in their browser and no server sees it — that's what #36 delivered. This is for the case that posture cannot serve: a team wanting one shared credential, central revocation, and an audit trail instead of a key pasted into everyone's browser.

## Why it's a separate package

**It is deliberately not part of `cre8-mcp`.** The knowledge plane holding no model key is an invariant with tests behind it, and putting custody there would quietly end it. A shell opts into `@tmorrow/cre8-key-custody` instead, and the plane stays exactly as key-free as it is today.

## Design

Envelope encryption, AES-256-GCM throughout. A fresh 256-bit data key encrypts each secret and is itself wrapped by a root key:

- **A stolen database is useless alone** — no root key, no plaintext.
- **Rotation rewraps records** without re-encrypting secrets.
- **Tenant and provider are bound in as AAD**, so a row is undecryptable in another tenant's context even if rows are swapped.

### Two things it refuses to do

**No development root key.** Material that isn't 32 bytes, or that looks like a placeholder — all-zero, repeating-pattern, or low-entropy — aborts startup with instructions. A custody system that silently falls back to a predictable key is *worse than none*, because it looks like protection and nothing in a test suite would notice.

**No datastore decision.** Durable storage a team can revoke from is an infrastructure choice, not a library one. This ships the `KeyRecordStore` interface plus an in-memory implementation for tests; a deployment supplies the rest.

### Plaintext never escapes

The key is handed *into* a callback rather than returned:

```ts
await custody.withKey(tenantId, "gemini", async (secret) => callProvider(secret));
```

There is no API that yields the key, so there's no handle to cache, log, or serialise by accident. Fingerprints are salted per tenant, so the same key held by two teams doesn't fingerprint alike — which would leak that they share a credential.

## Scope

- [ ] __Bug fix__ - non-breaking change which fixes an issue
- [x] __New feature__ - non-breaking change which adds functionality
- [ ] __Breaking change__ - fix or feature that would cause existing functionality to change

Purely additive: a new package nothing yet imports. No existing behaviour changes.

## Quality Checks

- [ ] Resolves an issue - Github Issue and/or Jira story created; No duplicates
- [ ] Follows branch name convention
- [ ] Version updated per [Semantic Versioning](https://semver.org) standard, if needed
- [x] Documentation - CSS comments, JS comments, Doc blocks
- [x] Did you use CSS Logical Properties for your CSS? — n/a, no CSS
- [x] Create React wrapper — n/a, no new web components
- [x] Storybook WC, React — n/a, no component changes
- [x] Performed a self-guided visual regression test for each respective brand — n/a, no UI
- [x] Did you add custom events in the WC? — n/a
- [ ] Updated CHANGELOG
- [x] I've performed a self-review of my code
- [x] My code passes linting and code quality checks
- [x] New and existing tests pass with my code changes
- [x] My code builds without generating new errors/warnings

## Verification

**20 tests**, chosen for the properties that matter if something goes wrong rather than for line coverage:

| Property | Covered |
| --- | --- |
| Sealed record contains no trace of the plaintext | ✓ (including a prefix check) |
| A different root key cannot open a record | ✓ |
| A record cannot be moved to another tenant | ✓ |
| A record cannot be reused for another provider | ✓ |
| Tampering is detected, not decrypted into garbage | ✓ |
| Rotation reports itself rather than failing obscurely | ✓ |
| Identical secrets differ on disk (fresh IV + data key) | ✓ |
| Revocation is immediate | ✓ |
| Cross-tenant use is rejected | ✓ |
| Audit trail records use without recording the key | ✓ |
| A failing audit sink can't break the operation | ✓ |
| Weak root keys refused (short / zero / repeating) | ✓ |

| Suite | Result |
| --- | --- |
| `pnpm test:custody` (new) | **20 passed** |
| `pnpm test:mcp` | 81 passed |
| `pnpm check:parity` | 13/13 |
| `pnpm test:a2ui` / `:agent` | PASS |
| studio | 27 passed |

I also re-verified the plane invariant still holds: **zero** model-key environment reads in `cre8-mcp/src`.

## Notes for the reviewer

- **Not production custody yet.** `LocalRootKey` holds the root key in process memory. A real deployment wants a KMS behind the `RootKeyProvider` interface so the root key never enters the app — the seam is there, the implementation is a deployment decision.
- Nothing imports this package yet; wiring it into a shell is a separate change, and worth doing only alongside the storage decision.
- The delimiter in AAD and map keys is `` — an unambiguous separator, since a NUL can't appear in a tenant id. Written as an escape rather than a raw byte, which had made the files register as binary to git.
- CHANGELOG not updated; happy to add an entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
